### PR TITLE
Adventus Veritatis

### DIFF
--- a/items/exotic.lua
+++ b/items/exotic.lua
@@ -1412,6 +1412,72 @@ local formidiulosus = {
 		code = { "Foegro" },
 	},
 }
+local veritas = {
+	dependencies = {
+		items = {
+			"c_cry_gateway",
+			"set_cry_exotic",
+		},
+	},
+	object_type = "Joker",
+	name = "cry-Veritas",
+	key = "veritas",
+	pos = { x = 0, y = 0 },
+	blueprint_compat = true,
+	config = { extra = { xmult = 1, xmult_mod = 1 } },
+	loc_vars = function(self, info_queue, center)
+		return {
+			vars = { center.ability.extra.xmult, center.ability.extra.xmult_mod },
+		}
+	end,
+	rarity = "cry_exotic",
+	cost = 50,
+	order = 519,
+	atlas = "placeholders",
+	calculate = function(self, card, context)
+		if context.before and context.cardarea == G.jokers and not context.blueprint and not context.retrigger_joker then
+			local purity = 20
+			if #context.full_hand > 5 then
+				purity = purity - 1 * (#context.full_hand + 5)
+			end
+			for i, v in pairs(context.scoring_hand) do
+				if v.config.center_key ~= "base" then -- non-functional
+					purity = purity - 1
+				end
+				if v.edition then
+					purity = purity - 1
+				end
+				if v.seal then
+					purity = purity - 1
+				end -- insert sticker check here
+			end
+			if false then -- next(context.poker_hands["None"])   intended: if hand played is none, +5 purity 
+				purity = purity + 5
+			elseif not (
+				next(context.poker_hands["High Card"])
+				or next(context.poker_hands["Pair"])
+				or next(context.poker_hands["Two Pair"])
+				or next(context.poker_hands["Three of a Kind"])
+				or next(context.poker_hands["Straight"])
+				or next(context.poker_hands["Flush"])
+				or next(context.poker_hands["Full House"])
+				or next(context.poker_hands["Four of a Kind"])
+				or next(context.poker_hands["Straight Flush"])
+				) then
+				purity = purity - 3
+			end
+			card.ability.extra.xmult = card.ability.extra.xmult + (card.ability.extra.xmult_mod * purity)
+			return { message = "Purity: " .. purity .. " -> " .. card.ability.extra.xmult }
+		end
+		if context.joker_main then 
+			return { xmult = card.ability.extra.xmult } 
+		end
+	end,
+	cry_credits = {
+		idea = { "Nova" },
+		code = { "Nova" },
+	},
+}
 local items = {
 	gateway,
 	iterum,
@@ -1435,6 +1501,7 @@ local items = {
 	--rescribere, [NEEDS REFACTOR]
 	duplicare,
 	formidiulosus,
+	veritas,
 }
 return {
 	name = "Exotic Jokers",

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -365,6 +365,15 @@ return {
 					"exceed Chips",
 				},
 			},
+			j_cry_veritas = {
+				name = "Veritas",
+				text = {
+					"This Joker gains {X:mult,C:white} X#2# {} Mult based on hand {C:attention}Purity{}",
+					"{C:attention}Purity{} starts at 20, and is reduced by",
+					"modifications to played cards and hands",
+					"{C:inactive}(Currently {X:mult,C:white} x#1# {C:inactive} Mult)",
+				},
+			},
 			bl_cry_vermillion_virus = {
 				name = "Vermillion Virus",
 				text = {


### PR DESCRIPTION
### Introducing Veritas
Or most of it, at least

Effects:
gains xmult based on hand "purity"; 1 xmult per purity

when hand played (context.after), increase purity of hand by 1 (if possible)

how purity works: by default, played hands have 20 purity. for every enhancement, seal, edition and sticker, as well as cards played over 5, purity is reduced by 1, playing secret hands reduces purity by 3, playing None increases purity by 5, and does not trigger the previous effect

when purity is increased by Veritas's effect, it does one of the following, in order of applicable (if not applicable, move to next)

remove 1 random enhancement/seal/edition/sticker (if any, triggers in that order), changes the suit of a random played card into non-matching ones (if its same of a kind; 5 flush/flush house type thing), destroys a random played card (only if >5 cards played)

also secret effect: allows you to play None of a kind


Code: Nova
Idea: Nova
Art: Soon To Be Nova (i'll be working on it tomorrow)

Balance opportunities: the purity : xmult ratio can be configured easily (and is misprintizeable), all of the purity related numbers are hard coded but can be changed easily (like making secret hands cost less purity, or increasing the starting amount), 

Todo: 
- Fix enhancement checking (currently always triggers, ideal is to only trigger on enhanced cards (and _maybe_ triggering extra times for quantum enhancements, aka owl cat)
- Add sticker checking (doesn't exist, ideal is to reduce by 1 for every sticker)
- Implement hand purification (the latter effect)
- Make the locs look _slightly_ clearer about what purity is
- Add None synergy (if/when None gets in; +5 purity instead of -3 when playing None, and veritas allows you to play None)