### PR TITLE
Bump Talisman Version

### DIFF
--- a/Cryptid.json
+++ b/Cryptid.json
@@ -11,7 +11,7 @@
 	"badge_text_colour": "FFFFFF",
 	"version": "0.5.5c",
 	"dependencies": [
-		"Talisman (>=2.2.0~dev)",
+		"Talisman (>=2.2.0a)",
 		"Steamodded (>=1.0.0~BETA-0406a)"
 	],
 	"conflicts": [


### PR DESCRIPTION
Bump talisman version, needed changes.

https://discord.com/channels/1264429948970733782/1264430590527012924/1362911092702974082

Latest release of talisman 2.2.0a contains the small hotfix to this. 