### PR TITLE
Crimson Stake Patch

### DIFF
--- a/lovely/stake.toml
+++ b/lovely/stake.toml
@@ -155,6 +155,32 @@ rental = self.ability and self.ability.rental,
 '''
 match_indent = true
 
+# Crimson Stake - Disable restocks on even antes
+[[patches]]
+[patches.pattern]
+target = "game.lua"
+pattern = '''for _,_ in pairs(G.GAME.current_round.voucher.spawn) do vouchers_to_spawn = vouchers_to_spawn + 1 end
+if vouchers_to_spawn < G.GAME.starting_params.vouchers_in_shop + (G.GAME.modifiers.extra_vouchers or 0) then
+    SMODS.get_next_vouchers(G.GAME.current_round.voucher)
+end
+for _, key in ipairs(G.GAME.current_round.voucher or {}) do
+    if G.P_CENTERS[key] and G.GAME.current_round.voucher.spawn[key] then
+        SMODS.add_voucher_to_shop(key)
+    end
+end'''
+position = "at"
+payload = '''if (G.GAME.modifiers.cry_voucher_restock_antes == nil or G.GAME.round_resets.ante % G.GAME.modifiers.cry_voucher_restock_antes == 0) then
+    for _,_ in pairs(G.GAME.current_round.voucher.spawn) do vouchers_to_spawn = vouchers_to_spawn + 1 end
+    if vouchers_to_spawn < G.GAME.starting_params.vouchers_in_shop + (G.GAME.modifiers.extra_vouchers or 0) then
+        SMODS.get_next_vouchers(G.GAME.current_round.voucher)
+    end
+    for _, key in ipairs(G.GAME.current_round.voucher or {}) do
+        if G.P_CENTERS[key] and G.GAME.current_round.voucher.spawn[key] then
+            SMODS.add_voucher_to_shop(key)
+        end
+    end
+end'''
+match_indent = true
 
 # Amber Stake - edit number of booster packs
 [[patches]]


### PR DESCRIPTION
Fixes Crimson Stake by patching game.lua to only restock shop vouchers on even numbered antes