### PR TITLE
Make The Decision, Tax and Clock appear in later antes

### DIFF
--- a/items/blind.lua
+++ b/items/blind.lua
@@ -249,7 +249,7 @@ local tax = {
 	key = "tax",
 	pos = { x = 0, y = 0 },
 	boss = {
-		min = 1,
+		min = 2,
 		max = 10,
 	},
 	atlas = "blinds",
@@ -327,7 +327,7 @@ local clock = {
 	pos = { x = 0, y = 1 },
 	mult = 0,
 	boss = {
-		min = 1,
+		min = 2,
 		max = 10,
 	},
 	config = {
@@ -758,7 +758,7 @@ local decision = {
 	pos = { x = 0, y = 20 },
 	dollars = 5,
 	boss = {
-		min = 1,
+		min = 4,
 		max = 666666,
 	},
 	atlas = "blinds",


### PR DESCRIPTION
There have been some complaints from how these spawn way too early, so it has been adjusted:
- The Decision will spawn from **Ante 4**
- The Clock will spawn from **Ante 2**
- The Tax will spawn from **Ante 2**

https://discord.com/channels/1264429948970733782/1264431244456755283/1369856059006517248