### PR TITLE
make the unique consumable type not show up in the collection since potion is hidden from collection so its useless

### DIFF
--- a/lib/content.lua
+++ b/lib/content.lua
@@ -312,6 +312,7 @@ SMODS.ConsumableType({
 	default = "c_cry_potion",
 	can_stack = false,
 	can_divide = false,
+	no_collection = true,
 })
 -- Pool used by Food Jokers
 SMODS.ObjectType({


### PR DESCRIPTION
yeah