### PR TITLE
Major crossmod Decision Fix + accounting for Unpleasant Card/Polterworx 

### DIFF
--- a/items/blind.lua
+++ b/items/blind.lua
@@ -802,10 +802,6 @@ local decision = {
 		G.GAME.cry_fastened = true
 		G.GAME.blind:wiggle()
 		G.GAME.blind.triggered = true
-		--PLACEHOLDER: Will open a random booster pack for now
-		--Booster will contain:
-		--4 cursed Jokers
-		--1 "tarot" to banish the rightmost joker
 		G.GAME.cry_make_a_decision = true
 		G.E_MANAGER:add_event(Event({
 			trigger = "before",

--- a/items/blind.lua
+++ b/items/blind.lua
@@ -802,6 +802,7 @@ local decision = {
 		--Booster will contain:
 		--4 cursed Jokers
 		--1 "tarot" to banish the rightmost joker
+		G.GAME.cry_make_a_decision = true
 		G.E_MANAGER:add_event(Event({
 			trigger = "before",
 			func = function()

--- a/lib/misc.lua
+++ b/lib/misc.lua
@@ -790,21 +790,3 @@ function Cryptid.cry_rankname_to_id(rankname)
 	end
 	return nil
 end
-
---The decision: Open GUI to make a decision then open a baneful buffoon pack (or)
-function Game:make_a_decision(dt)
-	if self.buttons then
-		self.buttons:remove()
-		self.buttons = nil
-	end
-	if self.shop and not G.GAME.USING_CODE then
-		self.shop:remove()
-		self.shop = nil
-	end
-
-	if not G.STATE_COMPLETE then
-		G.STATE_COMPLETE = true
-		G.GAME.cry_make_a_decision = true
-		G.GAME.blind:cry_before_cash()
-	end
-end

--- a/lib/overrides.lua
+++ b/lib/overrides.lua
@@ -1464,39 +1464,59 @@ end
 --Hook for booster skip to automatically destroy and banish the rightmost Joker, regardless of eternal
 local banefulSkipPenalty = G.FUNCS.skip_booster
 G.FUNCS.skip_booster = function(e)
-	if SMODS.OPENED_BOOSTER.config.center.cry_baneful_punishment then
-		if not G.GAME.banned_keys then
-			G.GAME.banned_keys = {}
-		end -- i have no idea if this is always initialised already tbh
-		if not G.GAME.cry_banned_pcards then
-			G.GAME.cry_banished_keys = {}
-		end
-		local c = nil
-		c = G.jokers.cards[#G.jokers.cards] --fallback to rightmost if somehow, you skipped without disabling and its unskippable.
-		--Iterate backwards to get the rightmost valid (non eternal or cursed) Joker
-		if G.jokers and G.jokers.cards then
-			for i = #G.jokers.cards, 1, -1 do
-				if
-					not (G.jokers.cards[i].ability.eternal or G.jokers.cards[i].config.center.rarity == "cry_cursed")
-				then
-					c = G.jokers.cards[i]
-					break
+	--Imported from my Epic Decision and also works in Polterworx and with unpleasant card, in the event youc an still skip with all eternals/cursed jokers
+	local obj = SMODS.OPENED_BOOSTER.config.center
+    -- local obj2 = G.P_BLINDS[G.GAME.round_resets.blind_choices.Boss]
+    if obj.unskippable and type(obj.unskippable) == "function" and obj:unskippable() == true then
+        if G.GAME.blind then
+			--Unplesant card will continously spam, so that will do for now without patching that; it is "unpleasant" after all;
+            -- play_sound('cancel', 0.8, 1)
+            -- local text = localize('k_nope_ex')
+            -- attention_text({
+            --     scale = 0.9, text = text, hold = 0.75, align = 'cm', offset = {x = 0,y = -2.7},major = G.play,colour = obj2.boss_colour or G.C.RED
+            -- })
+			G.GAME.blind:wiggle()
+            G.GAME.blind.triggered = true
+        end
+        if e and e.disable_button then
+            e.disable_button = nil
+           -- print("disble")
+        end
+    else
+		if SMODS.OPENED_BOOSTER.config.center.cry_baneful_punishment then
+			if not G.GAME.banned_keys then
+				G.GAME.banned_keys = {}
+			end -- i have no idea if this is always initialised already tbh
+			if not G.GAME.cry_banned_pcards then
+				G.GAME.cry_banished_keys = {}
+			end
+			local c = nil
+			c = G.jokers.cards[#G.jokers.cards] --fallback to rightmost if somehow, you skipped without disabling and its unskippable.
+			--Iterate backwards to get the rightmost valid (non eternal or cursed) Joker
+			if G.jokers and G.jokers.cards then
+				for i = #G.jokers.cards, 1, -1 do
+					if
+						not (G.jokers.cards[i].ability.eternal or G.jokers.cards[i].config.center.rarity == "cry_cursed")
+					then
+						c = G.jokers.cards[i]
+						break
+					end
 				end
 			end
-		end
 
-		if c.config.center.rarity == "cry_exotic" then
-			check_for_unlock({ type = "what_have_you_done" })
-		end
+			if c.config.center.rarity == "cry_exotic" then
+				check_for_unlock({ type = "what_have_you_done" })
+			end
 
-		G.GAME.cry_banished_keys[c.config.center.key] = true
-		if G.GAME.blind then
-			G.GAME.blind:wiggle()
-			G.GAME.blind.triggered = true
+			G.GAME.cry_banished_keys[c.config.center.key] = true
+			if G.GAME.blind then
+				G.GAME.blind:wiggle()
+				G.GAME.blind.triggered = true
+			end
+			c:start_dissolve()
 		end
-		c:start_dissolve()
+		banefulSkipPenalty(e)
 	end
-	banefulSkipPenalty(e)
 end
 
 --Overriding the skip booster function.

--- a/lovely/blind.toml
+++ b/lovely/blind.toml
@@ -278,14 +278,3 @@ end
 '''
 match_indent = true
 
-## Trying to investigate the problem
-[[patches]]
-[patches.pattern]
-target = '''functions/state_events.lua'''
-pattern = '''G.FUNCS.draw_from_deck_to_hand = function(e)'''
-position = "after"
-payload = '''
-      print("DDDD")
-'''
-match_indent = true
-

--- a/lovely/blind.toml
+++ b/lovely/blind.toml
@@ -105,20 +105,6 @@ end
 '''
 match_indent = true
 
-## Add state for EVAL
-
-[[patches]]
-[patches.pattern]
-target = "game.lua"
-pattern = '''if self.STATE == self.STATES.ROUND_EVAL then'''
-position = "before"
-payload = '''
-if self.STATE == self.STATES.CRY_MAKE_A_DECISION then
-	self:make_a_decision(dt)
-end
-'''
-match_indent = true
-
 ## Always be able to add cursed Jokers
 [[patches]]
 [patches.pattern]

--- a/lovely/blind.toml
+++ b/lovely/blind.toml
@@ -87,9 +87,7 @@ pattern = '''G.STATE = G.STATES.ROUND_EVAL
 position = "before"
 payload = '''
 if G.GAME.blind.config.blind.cry_before_cash and not G.GAME.blind.disabled then
-	G.STATE = G.STATES.CRY_MAKE_A_DECISION
-	G.STATE_COMPLETE = false
-	
+	G.GAME.blind:cry_before_cash()
 else
 G.GAME.cry_make_a_decision = nil
 
@@ -293,3 +291,15 @@ G.E_MANAGER:add_event(Event({
 end
 '''
 match_indent = true
+
+## Trying to investigate the problem
+[[patches]]
+[patches.pattern]
+target = '''functions/state_events.lua'''
+pattern = '''G.FUNCS.draw_from_deck_to_hand = function(e)'''
+position = "after"
+payload = '''
+      print("DDDD")
+'''
+match_indent = true
+


### PR DESCRIPTION
https://discord.com/channels/1264429948970733782/1370761753478037574/1370761753478037574

A user has reported a major crossmod issue involving repeatedly drawing the deck and upping the ante, softlocking the game. Turns out fixing the issue involved removing the need for an entire G.STATE for the decision, instead simply invoking cry_before_cash inside end_round(). This should also work with running only base cryptid.

There is also an additional fix for if you have Unpleasant Card or running Polterworx (the former automatically skips, the latter overrides the skip check functionality to always be skippable anytime), where if all jokers are eternal/cursed, it will no longer skip. Expect unpleasant noises if you have the unpleasant card.

https://github.com/user-attachments/assets/f3423a20-e425-45fe-8f4e-caf6e68f9d4d

https://github.com/user-attachments/assets/23f542c4-34ec-4236-816a-7db5e531b5b3

