### PR TITLE
change iterum to say "max retriggers" and not "max repetitions"

### DIFF
--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1883,7 +1883,7 @@ return {
 					"{C:attention}#2#{} time#<s>2#,",
 					"each played card gives",
 					"{X:mult,C:white} X#1# {} Mult when scored",
-					"{C:inactive}(Max {}{C:attention}#3#{}{C:inactive} repetitions)",
+					"{C:inactive}(Max {}{C:attention}#3#{}{C:inactive} retriggers)",
 				},
 			},
 			j_cry_jawbreaker = {


### PR DESCRIPTION
i have no idea why it was phrased like this in the first place; it quite literally isn't used anywhere else in the game and can be very confusing for players (see: https://discord.com/channels/1264429948970733782/1264430758764744714/1375536939821826079)