### PR TITLE
ctrl-v fix and fixed set_ability crash

### DIFF
--- a/items/code.lua
+++ b/items/code.lua
@@ -4171,6 +4171,19 @@ local ctrl_v = {
 		return {}
 	end,
 	can_use = function(self, card)
+		if (G.pack_cards and G.pack_cards.highlighted) then
+			for i = 1, #G.pack_cards.highlighted do
+				if G.pack_cards.highlighted[i].ability and 
+				(G.pack_cards.highlighted[i].ability.consumeable or
+				G.pack_cards.highlighted[i].ability.set == "Default" or
+				G.pack_cards.highlighted[i].ability.set == "Enhanced") then
+					-- nothing
+				else
+					return false
+				end
+			end
+		end
+
 		return #G.hand.highlighted + #G.consumeables.highlighted + (G.pack_cards and #G.pack_cards.highlighted or 0)
 			== 2
 	end,
@@ -4217,7 +4230,15 @@ local ctrl_v = {
 					if Incantation then
 						card:setQty(1)
 					end
-					G.consumeables:emplace(card)
+
+					-- Edit by IcyEthics: Needed to choose between not allowing copying playing cards or adding them to deck. Made it so they're added to deck.
+					if card.ability.set == "Default" or card.ability.set == "Enhanced" then
+						table.insert(G.playing_cards, card)
+						G.hand:emplace(card)
+						playing_card_joker_effects({ card })
+					else
+						G.consumeables:emplace(card)
+					end
 					return true
 				end,
 			}))

--- a/lib/gameset.lua
+++ b/lib/gameset.lua
@@ -595,6 +595,11 @@ function Card:set_ability(center, y, z)
 	if not center then
 		return
 	end
+	-- Addition by IcyEthics to make compatible with strings used on set_ability. Copied directly from the smods set_ability implementation
+	if type(center) == 'string' then
+        assert(G.P_CENTERS[center], ("Could not find center \"%s\""):format(center))
+        center = G.P_CENTERS[center]
+    end
 	if not center.config then
 		center.config = {} --crashproofing
 	end


### PR DESCRIPTION
Changed the implementation of the ctrl-v code card so it properly interacts with packs. It's also set up to not have issues with other mods that add objects that aren't jokers, consumables, or playing cards.

Also added a little converter to the start of the set_ability hook to ensure it stays compatible with the smods implementation