### PR TITLE
fixed Global sticker and added new context

### DIFF
--- a/items/code.lua
+++ b/items/code.lua
@@ -3415,12 +3415,28 @@ local global_sticker = {
 		card.hover_tilt = card.hover_tilt * 2
 	end,
 	calculate = function(self, card, context)
-		if (context.setting_blind or context.open_booster) and context.cardarea == G.deck then
-			draw_card(G.deck, G.hand, nil, nil, nil, card)
-			--[[card.globalticks = (card.globalticks or 1) - 1
-		if card.globalticks == 0 then
-			card.global = nil
-		end--]]
+		-- Added by IcyEthics
+		if context.cry_shuffling_area and context.cardarea == G.deck and context.cry_post_shuffle then
+
+			local _targetpos = nil
+			local _selfpos = nil
+
+			-- Iterate through every card in the deck to find both the location 
+			-- of the stickered card, and the highest placed non-stickered card
+			for i, _playingcard in ipairs(G.deck.cards) do
+				if _playingcard == card then
+					_selfpos = i
+				elseif not _playingcard.ability.cry_global_sticker then
+					_targetpos = i
+				end
+			end
+
+			if _targetpos == nil then _targetpos = #G.deck.cards end
+			if _selfpos == nil then _selfpos = #G.deck.cards end
+
+			-- Swaps the positions of the selected cards
+			G.deck.cards[_selfpos], G.deck.cards[_targetpos] = G.deck.cards[_targetpos], G.deck.cards[_selfpos]
+
 		end
 	end,
 }

--- a/lib/overrides.lua
+++ b/lib/overrides.lua
@@ -1600,3 +1600,15 @@ G.FUNCS.can_skip_booster = function(e)
 		e.config.button = nil
 	end
 end
+
+-- Added by IcyEthics: Adding a hook to the shuffle function so that there can be a context to modify randomization
+-- Any card using this will most likely want to use cry_post_shuffle. 
+-- added cry_pre_shuffle for posterity
+local o_ca_shuffle = CardArea.shuffle
+function CardArea:shuffle(_seed)
+ 	SMODS.calculate_context({cry_shuffling_area = true, cardarea = self, cry_pre_shuffle = true})
+	
+	o_ca_shuffle(self, _seed)
+
+	SMODS.calculate_context({cry_shuffling_area = true, cardarea = self, cry_post_shuffle = true})
+end


### PR DESCRIPTION
Global sticker now prioritizes being drawn, but doesn't force itself being drawn, and no longer exceeds maximum handsize A new context was added to allow for this

(also, I'm not sure what the approach is for documenting and crediting code. I'm adding my name mostly so people can ping me if the code isn't clear, or it turns out there's bugs in it, but I'm not sure if that's the proper approach)