### PR TITLE
Add value cap list for specific centers to misprintize

### DIFF
--- a/items/enhanced.lua
+++ b/items/enhanced.lua
@@ -344,7 +344,6 @@ return {
 					or center.name == "Mime"
 					or center.name == "Hack"
 					or center.name == "Sock and Buskin"
-					or center.name == "Hanging Chad"
 					or center.name == "Invisible Joker"
 					or center.name == "Swashbuckler"
 					or center.name == "Smeared Joker"
@@ -378,6 +377,36 @@ return {
 			then
 				self.config.center.immutable = true
 			end
+			G.P_CENTERS.j_hanging_chad.misprintize_caps = {extra = 40}
+			Cryptid.big_num_blacklist["c_magician"] = true
+			G.P_CENTERS.c_high_priestess.misprintize_caps = {planets = 100}
+			Cryptid.big_num_blacklist["c_empress"] = true
+			G.P_CENTERS.c_emperor.misprintize_caps = {tarots = 100}
+			Cryptid.big_num_blacklist["c_heirophant"] = true
+			Cryptid.big_num_blacklist["c_lovers"] = true
+			Cryptid.big_num_blacklist["c_chariot"] = true
+			Cryptid.big_num_blacklist["c_justice"] = true
+			Cryptid.big_num_blacklist["c_strength"] = true
+			Cryptid.big_num_blacklist["c_hanged_man"] = true
+			Cryptid.big_num_blacklist["c_death"] = true
+			Cryptid.big_num_blacklist["c_devil"] = true
+			Cryptid.big_num_blacklist["c_tower"] = true
+			Cryptid.big_num_blacklist["c_star"] = true
+			Cryptid.big_num_blacklist["c_moon"] = true
+			Cryptid.big_num_blacklist["c_sun"] = true
+			Cryptid.big_num_blacklist["c_world"] = true
+			Cryptid.big_num_blacklist["c_cry_eclipse"] = true
+			Cryptid.big_num_blacklist["c_cry_seraph"] = true
+			Cryptid.big_num_blacklist["c_cry_instability"] = true
+			G.P_CENTERS.c_cry_automaton.misprintize_caps = {create = 100}
+			G.P_CENTERS.c_familiar.misprintize_caps = {extra = 100}
+			G.P_CENTERS.c_grim.misprintize_caps = {extra = 100}
+			G.P_CENTERS.c_incantation.misprintize_caps = {extra = 100}
+			G.P_CENTERS.c_immolate.misprintize_caps = {destroy = 1e300}
+			Cryptid.big_num_blacklist["c_cry_instability"] = true
+			G.P_CENTERS.c_cryptid.misprintize_caps = {extra = 100, max_highlighted = 100}
+			G.P_CENTERS.c_immolate.misprintize_caps = {destroy = 1e300}
+			G.P_CENTERS.c_cry_chambered.misprintize_caps = {extra = {num_copies = 100}}
 			if Cryptid.safe_get(center, "name") == "Default Base" then -- scuffed
 				return sa(
 					self,

--- a/lib/misprintize.lua
+++ b/lib/misprintize.lua
@@ -323,7 +323,6 @@ function Cryptid.misprintize(card, override, force_reset, stack, grow_type, pow_
 		)
 	end
 	if clamps then
-		print(clamps)
 		for i, v in pairs(clamps) do
 			if type(v) == "table" and not v.tetrate then
 				for i2, v2 in pairs(v) do

--- a/lib/misprintize.lua
+++ b/lib/misprintize.lua
@@ -246,6 +246,7 @@ function Cryptid.sanity_check(val, is_big)
 	return val
 end
 function Cryptid.misprintize(card, override, force_reset, stack, grow_type, pow_level)
+	local clamps = card.config.center.misprintize_caps or {}
 	if Card.no(card, "immutable", true) then
 		force_reset = true
 	end
@@ -324,6 +325,21 @@ function Cryptid.misprintize(card, override, force_reset, stack, grow_type, pow_
 	if card.ability.consumeable then
 		for k, v in pairs(card.ability.consumeable) do
 			card.ability.consumeable[k] = Cryptid.deep_copy(card.ability[k])
+		end
+	end
+	if clamps then
+		for i, v in pairs(clamps) do
+			if type(v) == "table" and not v.tetrate then
+				for i2, v2 in pairs(v) do
+					if to_big(card.ability[i][i2]) > to_big(v2) then
+						card.ability[i][i2] = Cryptid.sanity_check(v2, Cryptid.is_card_big(card))
+					end
+				end
+			elseif (type(v) == "table" and v.tetrate) or type(v) == "number" then
+				if to_big(card.ability[i]) > to_big(v) then
+					card.ability[i] = Cryptid.sanity_check(v, Cryptid.is_card_big(card))
+				end
+			end
 		end
 	end
 end

--- a/lib/misprintize.lua
+++ b/lib/misprintize.lua
@@ -322,30 +322,25 @@ function Cryptid.misprintize(card, override, force_reset, stack, grow_type, pow_
 			pow_level
 		)
 	end
-	if card.ability.consumeable then
-		for k, v in pairs(card.ability.consumeable) do
-			card.ability.consumeable[k] = Cryptid.deep_copy(card.ability[k])
-		end
-	end
 	if clamps then
+		print(clamps)
 		for i, v in pairs(clamps) do
 			if type(v) == "table" and not v.tetrate then
 				for i2, v2 in pairs(v) do
 					if to_big(card.ability[i][i2]) > to_big(v2) then
 						card.ability[i][i2] = Cryptid.sanity_check(v2, Cryptid.is_card_big(card))
 					end
-					if card.consumeable[i] and to_big(card.consumeable[i][i2]) > to_big(v2) then
-						card.consumeable[i][i2] = Cryptid.sanity_check(v2, Cryptid.is_card_big(card))
-					end
 				end
 			elseif (type(v) == "table" and v.tetrate) or type(v) == "number" then
 				if to_big(card.ability[i]) > to_big(v) then
 					card.ability[i] = Cryptid.sanity_check(v, Cryptid.is_card_big(card))
 				end
-				if card.consumeable and to_big(card.consumeable[i]) > to_big(v) then
-					card.consumeable[i] = Cryptid.sanity_check(v, Cryptid.is_card_big(card))
-				end
 			end
+		end
+	end
+	if card.ability.consumeable then
+		for k, v in pairs(card.ability.consumeable) do
+			card.ability.consumeable[k] = Cryptid.deep_copy(card.ability[k])
 		end
 	end
 end

--- a/lib/misprintize.lua
+++ b/lib/misprintize.lua
@@ -334,10 +334,16 @@ function Cryptid.misprintize(card, override, force_reset, stack, grow_type, pow_
 					if to_big(card.ability[i][i2]) > to_big(v2) then
 						card.ability[i][i2] = Cryptid.sanity_check(v2, Cryptid.is_card_big(card))
 					end
+					if card.consumeable[i] and to_big(card.consumeable[i][i2]) > to_big(v2) then
+						card.consumeable[i][i2] = Cryptid.sanity_check(v2, Cryptid.is_card_big(card))
+					end
 				end
 			elseif (type(v) == "table" and v.tetrate) or type(v) == "number" then
 				if to_big(card.ability[i]) > to_big(v) then
 					card.ability[i] = Cryptid.sanity_check(v, Cryptid.is_card_big(card))
+				end
+				if card.consumeable and to_big(card.consumeable[i]) > to_big(v) then
+					card.consumeable[i] = Cryptid.sanity_check(v, Cryptid.is_card_big(card))
 				end
 			end
 		end


### PR DESCRIPTION
Centers can now define misprintize_caps as a table which represents a list of values to be capped in the ability table additionally tables like extra in the ability table can also be setup in the misprintize_caps table to be capped for Cryptid for example capping the two values would be like this G.P_CENTERS.c_cryptid.mizprintize_caps = {extra = 50, max_highlighted = 50}

for supercell it would be something like this
misprintize_caps = {extra = {stat1 = 20, stat2 = 20, money = 20}},
in the centers definition