### PR TITLE
Fix Sapphire Stamp using outdated methods to increase selection limit

### DIFF
--- a/items/blind.lua
+++ b/items/blind.lua
@@ -1015,7 +1015,8 @@ local sapphire_stamp = {
 	set_blind = function(self, reset, silent)
 		if not reset then
 			G.GAME.stamp_mod = true
-			G.hand.config.highlighted_limit = G.hand.config.highlighted_limit + 1
+			SMODS.change_play_limit(1)
+			SMODS.change_discard_limit(1)
 		end
 	end,
 	defeat = function(self, silent)
@@ -1023,7 +1024,8 @@ local sapphire_stamp = {
 			G.GAME.stamp_mod = nil
 		end
 		if not G.GAME.blind.disabled then
-			G.hand.config.highlighted_limit = G.hand.config.highlighted_limit - 1
+			SMODS.change_play_limit(-1)
+			SMODS.change_discard_limit(-1)
 		end
 	end,
 	disable = function(self, silent)
@@ -1031,7 +1033,8 @@ local sapphire_stamp = {
 			G.GAME.stamp_mod = nil
 		end
 		if not G.GAME.blind.disabled then
-			G.hand.config.highlighted_limit = G.hand.config.highlighted_limit - 1
+			SMODS.change_play_limit(-1)
+			SMODS.change_discard_limit(-1)
 		end
 	end,
 }


### PR DESCRIPTION
Steamodded beta 0530b introduced a new hand limit API that's much easier to navigate around, at the cost of breaking all mods that changed how many cards you could select. Cryptid version 0.5.7 updated most selection limit-based features to match this change, but as of the most recent release (version 0.5.9), the code for the Sapphire Stamp boss blind was not changed. This results in the player being allowed to select extra cards, but not being allowed to play or discard the selected hand if the amount of cards selected is above their pre-Sapphire Stamp limit.