### PR TITLE
update CN translation for 0.5.10~dev3 and fix wrong expressions

### DIFF
--- a/localization/zh_CN.lua
+++ b/localization/zh_CN.lua
@@ -7,11 +7,25 @@ return {
 					"每张牌也是一张{C:attention}随机{}消耗牌",
 					"{C:inactive,s:0.8}{C:attention,s:0.8}(Consume Card Deck){C:inactive,s:0.8}",
 				},
+				unlock = {
+					"使用{C:spectral}次元之袋",
+				},
 			},
 			b_cry_antimatter = {
 				name = "反物质牌组",
 				text = {
-					"拥有{C:legendary,E:1}所有牌组的{}增益效果",
+					"拥有{C:attention}所有{}牌组的{C:legendary,E:1}增益效果",
+				},
+				unlock = {
+					"使用{C:attention}黑色牌组",
+					"在{C:attention}金注{}中获胜",
+				},
+			},
+			b_cry_antimatter_balanced = {
+				name = "反物质牌组",
+				text = {
+					"拥有{C:attention}所有{}在{C:gold}金注{}中获胜过的",
+					"牌组的{C:legendary,E:1}增益效果",
 				},
 			},
 			b_cry_beige = {
@@ -20,6 +34,11 @@ return {
 					"{C:attention}普通{}小丑具有",
 					"{C:attention}四倍{}的效果",
 				},
+				unlock = {
+					"在收藏中",
+					"至少发现",
+					"{C:attention}200{}个项目",
+				},
 			},
 			b_cry_beta = {
 				name = "怀旧牌组",
@@ -27,6 +46,9 @@ return {
 					"{C:attention}小丑牌槽{} 和 {C:attention}消耗牌槽{}",
 					"{C:attention}合并",
 					"boss底注被替换为它们的怀旧版本",
+				},
+				unlock = {
+					"在{C:attention}粉红注{}中获胜",
 				},
 			},
 			b_cry_blank = {
@@ -38,8 +60,12 @@ return {
 			b_cry_bountiful = {
 				name = "丰饶牌组",
 				text = {
-					"每次{C:attention}出牌{} 或 {C:attention}弃牌{}后",
+					"每次{C:attention}出牌{}或{C:attention}弃牌{}后",
 					"固定抽五张牌",
+				},
+				unlock = {
+					"不使用{C:red}弃牌",
+					"击败{C:attention}巨蟒",
 				},
 			},
 			b_cry_conveyor = {
@@ -50,6 +76,9 @@ return {
 					"{C:attention}复制{}最右边的小丑牌",
 					"并且{C:attention}销毁{}最左边的小丑牌",
 				},
+				unlock = {
+					"使用{C:spectral}模拟",
+				},
 			},
 			b_cry_critical = {
 				name = "暴击牌组",
@@ -57,6 +86,9 @@ return {
 					"每打出一手牌后，",
 					"{C:green}#1#/4{}几率获得{X:dark_edition,C:white}^2{}倍率",
 					"{C:green}#1#/8{}几率获得{X:dark_edition,C:white}^0.5{}倍率",
+				},
+				unlock = {
+					"拥有一张{C:attention}灌铅{}小丑",
 				},
 			},
 			["b_cry_cry-Blue_deck"] = {
@@ -94,8 +126,8 @@ return {
 			["b_cry_cry-bonus_deck"] = {
 				name = "教皇牌组",
 				text = {
-					"所有的 {C:attention}手牌{}",
-					"都是 {C:attention,T:m_bonus}奖励牌{}",
+					"所有的{C:attention}手牌{}",
+					"都是{C:attention,T:m_bonus}奖励牌{}",
 					"不能更改增强类型",
 					"{s:0.8,C:inactive}",
 				},
@@ -143,8 +175,8 @@ return {
 			["b_cry_cry-gold_deck"] = {
 				name = "恶魔牌组",
 				text = {
-					"所有的 {C:attention}手牌{}",
-					"都是 {C:attention,T:m_gold}黄金牌{}",
+					"所有的{C:attention}手牌{}",
+					"都是{C:attention,T:m_gold}黄金牌{}",
 					"不能更改增强类型",
 					"{s:0.8,C:inactive}",
 				},
@@ -168,8 +200,8 @@ return {
 			["b_cry_cry-lucky_deck"] = {
 				name = "魔术师牌组",
 				text = {
-					"所有的 {C:attention}手牌{}",
-					"都是 {C:attention,T:m_lucky}幸运牌{}",
+					"所有的{C:attention}手牌{}",
+					"都是{C:attention,T:m_lucky}幸运牌{}",
 					"不能更改增强类型",
 					"{s:0.8,C:inactive}",
 				},
@@ -177,8 +209,8 @@ return {
 			["b_cry_cry-mult_deck"] = {
 				name = "皇后牌组",
 				text = {
-					"所有的 {C:attention}手牌{}",
-					"都是 {C:attention,T:m_mult}倍率牌{}",
+					"所有的{C:attention}手牌{}",
+					"都是{C:attention,T:m_mult}倍率牌{}",
 					"不能更改增强类型",
 					"{s:0.8,C:inactive}",
 				},
@@ -223,8 +255,8 @@ return {
 			["b_cry_cry-steel_deck"] = {
 				name = "战车牌组",
 				text = {
-					"所有的 {C:attention}手牌{}",
-					"都是 {C:attention,T:m_steel}钢铁牌{}",
+					"所有的{C:attention}手牌{}",
+					"都是{C:attention,T:m_steel}钢铁牌{}",
 					"不能更改增强类型",
 					"{s:0.8,C:inactive}",
 				},
@@ -232,8 +264,8 @@ return {
 			["b_cry_cry-stone_deck"] = {
 				name = "石头牌组",
 				text = {
-					"所有的 {C:attention}手牌{}",
-					"都是 {C:attention,T:m_stone}石头牌{}",
+					"所有的{C:attention}手牌{}",
+					"都是{C:attention,T:m_stone}石头牌{}",
 					"不能更改增强类型",
 					"{s:0.8,C:inactive}",
 				},
@@ -241,8 +273,8 @@ return {
 			["b_cry_cry-wild_deck"] = {
 				name = "爱人牌组",
 				text = {
-					"所有的 {C:attention}手牌{}",
-					"都是 {C:attention,T:m_wild}万能牌{}",
+					"所有的{C:attention}手牌{}",
+					"都是{C:attention,T:m_wild}万能牌{}",
 					"不能更改增强类型",
 					"{s:0.8,C:inactive}",
 				},
@@ -358,11 +390,26 @@ return {
 					"{s:0.8,C:inactive}",
 				},
 			},
+			b_cry_e_deck = {
+				name = "版本牌组",
+				text = {
+					"所有牌均为{C:dark_edition}#1#{}",
+					"卡牌无法更改版本",
+					"{C:inactive}（点击可编辑）",
+				},
+				unlock = {
+					"发现所有",
+					"{C:dark_edition}版本",
+				},
+			},
 			b_cry_encoded = {
 				name = "编码牌组",
 				text = {
 					"以一张{C:cry_code,T:j_cry_CodeJoker}代码小丑{}和一张{C:cry_code,T:j_cry_copypaste}复制/粘贴{}开始",
 					"商店中只出现{C:cry_code}代码牌{}",
+				},
+				unlock = {
+					"使用{C:spectral}://指针",
 				},
 			},
 			b_cry_equilibrium = {
@@ -372,6 +419,21 @@ return {
 					"商店中出现的{C:attention}几率相同{}，",
 					"以{C:attention,T:v_overstock_plus}库存过剩加强版{}开始游戏",
 				},
+				unlock = {
+					"同时拥有{C:attention}100个小丑",
+					"{C:inactive,s:0.7}译者注:解锁条件应该不是这个",
+					"{C:inactive,s:0.7}虽然英文原文是这么写的",
+				},
+			},
+			b_cry_et_deck = {
+				name = "增强牌组",
+				text = {
+					"所有{C:attention}扑克牌{}均为{C:attention}#1#{}",
+					"{C:inactive}（点击可编辑）",
+				},
+				unlock = {
+					"使用{C:spectral}虚空",
+				},
 			},
 			b_cry_glowing = {
 				name = "发光牌组",
@@ -380,6 +442,10 @@ return {
 					"所有小丑牌的数值乘以{X:dark_edition,C:white}X1.25{}",
 					"{X:cry_jolly,C:white,s:0.8} Jolly#1#Open#1#Winner#1#-#1#wawa#1#person",
 				},
+				unlock = {
+					"使用{C:attention}四重卡组",
+					"赢一局",
+				},
 			},
 			b_cry_infinite = {
 				name = "无限牌组",
@@ -387,14 +453,20 @@ return {
 					"你可以选择{C:attention}任意数量的卡牌{}",
 					"{C:attention}+1{}手牌上限",
 				},
+				unlock = {
+					"打出一手牌至少包含{C:attention}6{}张牌",
+				},
 			},
 			b_cry_legendary = {
 				name = "传奇牌组",
 				text = {
-					"以一张 {C:legendary}传奇{C:legendary} 小丑牌开始",
+					"以一张{C:legendary}传奇{C:legendary}小丑牌开始",
 					"击败Boss盲注后",
 					"{C:green}1 / 5{} 几率创建另外一张",
 					"{C:inactive}(必须有空间){}",
+				},
+				unlock = {
+					"同时拥有{C:attention}2个传奇小丑",
 				},
 			},
 			b_cry_misprint = {
@@ -403,12 +475,18 @@ return {
 					"卡牌价格，手牌的数值",
 					"都是{C:attention}随机{}数值",
 				},
+				unlock = {
+					"拥有一个{C:dark_edition}故障{C:attention}小丑",
+				},
 			},
 			b_cry_redeemed = {
 				name = "赎回牌组",
 				text = {
 					"购买{C:attention}优惠券{}时，",
 					"获得其{C:attention}额外等级{}",
+				},
+				unlock = {
+					"发现所有{C:attention}优惠券{}",
 				},
 			},
 			b_cry_source_deck = {
@@ -422,9 +500,44 @@ return {
 			b_cry_spooky = {
 				name = "万圣节牌组",
 				text = {
-					"以一张{C:eternal}永恒{} {C:attention,T:j_cry_chocolate_dice}巧克力骰{}开始",
-					"每次{C:attention}底注{}之后 ",
-					"创建一个{C:cry_candy}糖果{}或 {X:cry_cursed,C:white}诅咒{}",
+					"以一张{C:eternal}永恒{}{C:attention,T:j_cry_chocolate_dice}巧克力骰{}开始",
+					"每个{C:attention}底注{}结束后",
+					"创建一个{C:cry_candy}糖果{}或{X:cry_cursed,C:white}诅咒{}",
+				},
+				unlock = {
+					"拥有一张{C:cry_candy}糖果{C:attention}小丑",
+				},
+			},
+			b_cry_sk_deck = {
+				name = "贴纸牌组",
+				text = {
+					"所有牌均为{C:attention}#1#{}",
+					"{C:inactive}（点击可编辑）",
+				},
+				unlock = {
+					"使用{C:spectral}锁定",
+				},
+			},
+			b_cry_sl_deck = {
+				name = "蜡封牌组",
+				text = {
+					"所有扑克牌均带有{C:dark_edition}#1#{}蜡封",
+					"卡牌无法更改蜡封",
+					"{C:inactive}（点击可编辑）",
+				},
+				unlock = {
+					"使用{C:spectral}台风",
+				},
+			},
+			b_cry_st_deck = {
+				name = "花色牌组",
+				text = {
+					"所有扑克牌均为{C:dark_edition}#1#",
+					"无法更改花色",
+					"{C:inactive}（点击可编辑）",
+				},
+				unlock = {
+					"使用{C:spectral}复录",
 				},
 			},
 			b_cry_very_fair = {
@@ -432,6 +545,10 @@ return {
 				text = {
 					"每回合{C:blue}-2{}手牌，{C:red}-2{}弃牌",
 					"{C:attention}优惠券{}不再出现在商店中",
+				},
+				unlock = {
+					"使用{C:attention}黑色牌组",
+					"赢一局",
 				},
 			},
 			b_cry_wormhole = {
@@ -441,6 +558,9 @@ return {
 					"小丑牌都{C:attention}20X+{}",
 					"更可能是{C:dark_edition}负片{}",
 					"{C:attention}-2{}小丑牌槽",
+				},
+				unlock = {
+					"拥有一张{C:attention}域外{}小丑",
 				},
 			},
 		},
@@ -506,7 +626,7 @@ return {
 			bl_cry_oldflint = {
 				name = "怀旧 燧石",
 				text = {
-					"包含同花顺的出牌不计分",
+					"包含同花的出牌不计分",
 				},
 			},
 			bl_cry_oldhouse = {
@@ -550,6 +670,40 @@ return {
 				text = {
 					"史诗及以上稀有度的",
 					"小丑被削弱",
+				},
+			},
+			bl_cry_scorch = {
+				name = "灼烧",
+				text = {
+					"必须出5张牌",
+					"摧毁打出和弃掉的牌",
+				},
+			},
+			bl_cry_greed = {
+				name = "贪婪",
+				text = {
+					"选择时，每$#1#增加#2#盲注要求",
+				},
+			},
+			bl_cry_repulsor = {
+				name = "排斥",
+				text = {
+					"重新触发最右侧和最左侧的小丑，",
+					"其他所有小丑不触发",
+				},
+			},
+			bl_cry_chromatic = {
+				name = "彩色",
+				text = {
+					"在出牌次数为奇数次时的打出手牌",
+					"总分会减去手牌得分",
+				},
+			},
+			bl_cry_landlord = {
+				name = "房东",
+				text = {
+					"打出手牌时",
+					"对随机一个小丑添加租用贴纸",
 				},
 			},
 			bl_cry_pinkbow = {
@@ -598,6 +752,12 @@ return {
 					"手中的牌",
 				},
 			},
+			bl_cry_trophy = {
+				name = "柠檬奖杯",
+				text = {
+					"倍率不能超过筹码数",
+				},
+			},
 			bl_cry_vermillion_virus = {
 				name = "朱红病毒",
 				text = {
@@ -608,6 +768,13 @@ return {
 				name = "风车",
 				text = {
 					"削弱所有的罕见小丑",
+				},
+			},
+			bl_cry_decision = {
+				name = "抉择",
+				text = {
+					"出牌或弃牌时固定小丑位置",
+					"回合结束后打开一个诅咒小丑包",
 				},
 			},
 		},
@@ -622,17 +789,24 @@ return {
 			c_cry_class = {
 				name = "://类别",
 				text = {
-					"将 {C:cry_code}#1#{} 选中的牌",
-					"转换为 {C:cry_code}指令{} 下的增强",
+					"将{C:cry_code}#1#{}选中的牌",
+					"转换为{C:cry_code}指令{}下的增强",
 					"可用指令：{C:cry_code}bonus{},{C:cry_code}mult{},{C:cry_code}wild{},{C:cry_code}glass{}",
 					"{C:cry_code}steel{},{C:cry_code}stone{},{C:cry_code}gold{},{C:cry_code}lucky{},{C:cry_code}echo{},{C:cry_code}light{}",
+				},
+			},
+			c_cry_global = {
+				name = "://全局",
+				text = {
+					"选择一张扑克牌",
+					"为其添加{C:cry_code}全局{}贴纸",
 				},
 			},
 			c_cry_commit = {
 				name = "://提交",
 				text = {
-					"摧毁一张 {C:cry_code}选中的{} 小丑牌,",
-					"创造一张 {C:cry_code}新的相同 {C:cry_code}稀有度的{} 小丑牌",
+					"摧毁一张{C:cry_code}选中的{}小丑牌,",
+					"创造一张{C:cry_code}新的相同{C:cry_code}稀有度的{}小丑牌",
 				},
 			},
 			c_cry_crash = {
@@ -641,47 +815,49 @@ return {
 					"{C:cry_code,E:1}警告！使用此牌会导致游戏崩溃！",
 				},
 			},
+			c_cry_keygen = {
+				name = "://密钥",
+				text = {
+					"创建一张随机的{C:cry_code}易腐香蕉{}优惠券，",
+					"{C:cry_code}摧毁{}此前以此方式创建的优惠券。",
+				},
+			},
 			c_cry_ctrl_v = {
 				name = "://CTRL+V",
 				text = {
-					"复制一张 {C:cry_code}选择的{} 卡牌或消耗牌",
+					"复制一张{C:cry_code}选择的{}卡牌或消耗牌",
 				},
 			},
 			c_cry_delete = {
 				name = "://删除",
 				text = {
-					"{C:cry_code}永久{} 移除一个",
-					"{C:cry_code}选中的{} 商店物品",
+					"{C:cry_code}永久{}移除一个",
+					"{C:cry_code}选中的{}商店物品",
 					"{C:inactive,s:0.8}本次游戏中该物品不会再出现",
 				},
 			},
 			c_cry_divide = {
 				name = "://分割",
 				text = {
-					"{C:cry_code}减半{} 当前商店中的",
+					"{C:cry_code}减半{}当前商店中的",
 					"所有标价",
 				},
 			},
 			c_cry_exploit = {
 				name = "://利用",
 				text = {
-					"{C:cry_code}下一{} 手牌",
-					"",
+					"{C:cry_code}下一手牌{}",
 					"被计算为",
-					"",
-					"{C:cry_code}指令{} 下的牌型",
-					"",
+					"{C:cry_code}指令{}下的牌型",
 					"{C:inactive,s:0.8}必须是已发现的手牌类型",
-					"",
 					"可用指令：{C:cry_code}full house（葫芦）{},{C:cry_code}flush（同花）{},{C:cry_code}straight flush（同花顺）{},{C:cry_code}four of a kind（四条）{}",
-					"",
 					"{C:cry_code}three of a kind（三条）{},{C:cry_code}pair（对子）{},{C:cry_code}two pair（两对）{},{C:cry_code}high（高牌）{}",
 				},
 			},
 			c_cry_hook = {
 				name = "://钩子",
 				text = {
-					"选择两张小丑牌，使它们 {C:cry_code}钩住{}",
+					"选择两张小丑牌，使它们{C:cry_code}钩住{}",
 					"{C:inactive,s:0.8}其中一张被触发时，触发另一张（仅当两个效果的触发时机相同时有效）",
 				},
 			},
@@ -702,51 +878,72 @@ return {
 			c_cry_malware = {
 				name = "://木马",
 				text = {
-					"给所有的{C:cry_code}无版本手牌{} ",
-					"添加 {C:dark_edition}故障{}版本",
+					"给所有的{C:cry_code}无版本手牌{}",
+					"添加{C:dark_edition}故障{}版本",
+				},
+			},
+			c_cry_nperror = {
+				name = "://NP错误",
+				text = {
+					"将{C:cry_code}上一手打出的牌{}",
+					"返回你的手牌",
 				},
 			},
 			c_cry_merge = {
 				name = "://合并",
 				text = {
-					"将一张 {C:cry_code}消耗牌",
-					"与一张 {C:cry_code}手牌{} 合并",
+					"将一张{C:cry_code}消耗牌",
+					"与一张{C:cry_code}手牌{}合并",
 				},
 			},
 			c_cry_multiply = {
 				name = "://乘法",
 				text = {
 					"选择一张牌，使其所有数值{C:cry_code}翻倍{}",
-					"直到 {C:cry_code}回合结束{}",
+					"直到{C:cry_code}回合结束{}",
 				},
 			},
 			c_cry_oboe = {
-				name = "://偏差1",
+				name = "://偏差",
 				text = {
-					"打开的下一个 {C:cry_code}补充包{} 有",
-					"{C:cry_code}#1#{} 张额外卡牌和",
-					"{C:cry_code}#1#{} 次额外选择",
+					"打开的下一个{C:cry_code}补充包{}有",
+					"{C:cry_code}#1#{}张额外卡牌和",
+					"{C:cry_code}#1#{}次额外选择",
 					"{C:inactive}(当前为 {C:cry_code}+#2#{C:inactive})",
+				},
+			},
+			c_cry_assemble = {
+				name = "://汇编",
+				text = {
+					"为{C:cry_code}选中的手牌牌型{}增加{C:cry_code}倍率{}，",
+					"数值等于拥有的小丑数量",
 				},
 			},
 			c_cry_patch = {
 				name = "://补丁",
 				text = {
-					"从当前所有可见的物品中移除",
-					"贴纸和负面效果",
+					"从当前所有可见的物品中移除负面效果",
+					"{C:cry_code}重置{}商店状态",
+				},
+			},
+			c_cry_cryupdate = {
+				name = "://UPDATE",
+				text = {
+					"将在未来的{C:cry_code}更新{}中",
+					"{C:cry_code}确定{}功能",
 				},
 			},
 			c_cry_payload = {
 				name = "://载荷",
 				text = {
 					"下一个被击败的盲注",
-					"给与 {C:cry_code}X#1#{} 利息（乘法叠加）",
+					"给予{C:cry_code}X#1#{}利息（乘法叠加）",
 				},
 			},
 			c_cry_reboot = {
 				name = "://重启",
 				text = {
-					"补充 {C:blue}手牌{} 和 {C:red}弃牌{} 次数,",
+					"补充{C:blue}手牌{}和{C:red}弃牌{}次数,",
 					"将{C:cry_code}所有{}牌返回牌堆",
 					"并抽取一组{C:cry_code}新的{}手牌",
 				},
@@ -754,16 +951,23 @@ return {
 			c_cry_revert = {
 				name = "://还原",
 				text = {
-					"将 {C:cry_code}游戏状态{} 回溯到",
+					"将{C:cry_code}游戏状态{}回溯到",
 					"{C:cry_code}这一底注的开始时{}",
+				},
+			},
+			c_cry_cryfunction = {
+				name = "函数://",
+				text = {
+					"保存最近使用的3个{C:cry_code}消耗牌{}",
+					"再次使用此卡时，创建第一个的复制并添加{C:cry_code}函数://{}贴纸",
 				},
 			},
 			c_cry_rework = {
 				name = "://重制",
 				text = {
-					"摧毁一张 {C:cry_code}选中的{} 小丑牌,",
-					"创造该小丑牌的 {C:cry_code}重制标签{}，并",
-					"获得一个 {C:cry_code}升级的{} 版本",
+					"摧毁一张{C:cry_code}选中的{}小丑牌,",
+					"创造该小丑牌的{C:cry_code}重制标签{}并",
+					"获得一个{C:cry_code}升级的{}版本",
 					"{C:inactive,s:0.8}版本通过收藏中的顺序升级{}",
 					"{C:inactive,s:0.8}基础，闪箔，镭射，多彩，负片，故障，马赛克，过曝，{}",
 					"{C:inactive,s:0.8}灰质琉璃，鎏金，模糊，噪声，星界，欢愉，双面，基础{}",
@@ -772,38 +976,182 @@ return {
 			c_cry_run = {
 				name = "://运行",
 				text = {
-					"在 {C:cry_code}盲注",
-					"期间拜访 {C:cry_code}商店",
+					"在{C:cry_code}盲注",
+					"期间拜访{C:cry_code}商店",
 				},
 			},
 			c_cry_seed = {
 				name = "://种子",
 				text = {
 					"选择一张小丑牌或手牌",
-					"使它们获得 {C:cry_code}灌铅{}效果",
+					"使它们获得{C:cry_code}灌铅{}效果",
 					"概率效果必然被触发",
 				},
 			},
 			c_cry_semicolon = {
 				name = ";//",
 				text = {
-					"结束当前非Boss {C:cry_code}盲注{}",
+					"结束当前非Boss{C:cry_code}盲注{}",
 					"{C:cry_code}不获得金钱{}",
 				},
 			},
 			c_cry_spaghetti = {
 				name = "://意面",
 				text = {
-					"生成一张 {C:cry_code}故障版本{}的",
+					"生成一张{C:cry_code}故障版本{}的",
 					"食物小丑牌",
 				},
 			},
 			c_cry_variable = {
 				name = "://变量",
 				text = {
-					"将 {C:cry_code}#1#{} 张选中的牌",
-					"转换为 {C:cry_code}指令{} 下的牌型",
+					"将{C:cry_code}#1#{}张选中的牌",
+					"转换为{C:cry_code}指令{}下的牌型",
 					"可用指令：{C:cry_code}1~13,A,J,Q,K{}",
+				},
+			},
+			c_cry_log = {
+				name = "://日志",
+				text = {
+					"显示以下任一{C:cry_code}读数{}的值：",
+					"{C:attention}下一个{}底注的{C:attention}Boss盲注{}和{C:attention}优惠券{},",
+					"接下来商店中的{C:attention}5{}个{C:attention}小丑{}，或者",
+					"接下来{C:attention}10{}张将要被{C:attention}抽取{}的手牌",
+					"{C:inactive}(如果在盲注中){}",
+					"{C:inactive,S:0.7}(译者注:在0.5.10~dev3版本中,使用第一个选项会导致attempt to index a nil value报错)",
+					"{C:inactive,S:0.7}(第二个选项看不到小丑,第三个选项看不到花色)",
+					"{C:inactive,S:0.7}(但是译者不能完全确定,可以尝试一下)",
+				},
+			},
+			c_cry_quantify = {
+				name = "://量化",
+				text = {
+					"将{C:attention}#1#{}张选择的",
+					"{C:attention}手牌{}或{C:attention}补充包{}",
+					"放到{C:attention}小丑槽{}槽位中",
+				},
+			},
+			c_cry_declare = {
+				name = "://声明",
+				text = {
+					"你{C:attention}现在{}选择的手牌",
+					"变成一张包含{C:attention}#1#{}的{C:cry_code}新的{}牌型",
+					"你最多可以创造{C:attention}3{}{C:inactive}[#2#]{}种牌型",
+				},
+			},
+		},
+		["Content Set"] = {
+			set_cry_blind = {
+				name = "盲注集合",
+				text = {
+					"包含Cryptid新增的{C:attention}Boss盲注{}",
+				},
+			},
+			set_cry_code = {
+				name = "代码牌集合",
+				text = {
+					"包含{C:cry_code}代码牌{}及",
+					"相关内容",
+				},
+			},
+			set_cry_cursed = {
+				name = "诅咒小丑集合",
+				text = {
+					"带有{X:cry_cursed,C:white}诅咒{}稀有度的有害小丑",
+				},
+			},
+			set_cry_deck = {
+				name = "牌组集合",
+				text = {
+					"Cryptid新增的{C:attention}牌组{}",
+				},
+			},
+			set_cry_epic = {
+				name = "史诗小丑集合",
+				text = {
+					"带有{C:cry_epic}史诗{}稀有度的小丑",
+					"{C:inactive,s:0.8}（介于稀有和传奇之间）",
+				},
+			},
+			set_cry_exotic = {
+				name = "域外小丑集合",
+				text = {
+					"带有{C:cry_exotic}域外{}稀有度的强力小丑",
+				},
+			},
+			set_cry_m = {
+				name = "M小丑集合",
+				text = {
+					"与字母{C:attention}M{}相关的小丑，",
+					"以及{C:attention}开心小丑",
+				},
+			},
+			set_cry_meme = {
+				name = "梗小丑集合",
+				text = {
+					"包含多类梗相关内容",
+				},
+			},
+			set_cry_misc = {
+				name = "杂项集合",
+				text = {
+					"不适合其他{C:cry_ascendant}主题集合{}的内容",
+				},
+			},
+			set_cry_misc_joker = {
+				name = "杂项小丑集合",
+				text = {
+					"不适合其他{C:cry_ascendant}主题集合{}的{C:attention}小丑{}",
+				},
+			},
+			set_cry_planet = {
+				name = "星球牌集合",
+				text = {
+					"Cryptid新增的{C:planet}星球{}牌",
+				},
+			},
+			set_cry_poker_hand_stuff = {
+				name = "扑克手牌扩展",
+				text = {
+					"新增5种{C:attention}扑克手牌{}，",
+					"并启用{C:attention}晋升手牌",
+				},
+			},
+			set_cry_spectral = {
+				name = "幻灵牌集合",
+				text = {
+					"Cryptid新增的{C:spectral}幻灵{}牌",
+				},
+			},
+			set_cry_spooky = {
+				name = "万圣节更新内容",
+				text = {
+					"万圣节更新内容",
+					"包括{C:cry_candy}糖果{}小丑",
+				},
+			},
+			set_cry_tag = {
+				name = "标签集合",
+				text = {
+					"Cryptid新增的{C:attention}标签{}",
+				},
+			},
+			set_cry_tier3 = {
+				name = "三阶优惠券",
+				text = {
+					"优惠券的额外{C:attention}等级{}",
+				},
+			},
+			set_cry_timer = {
+				name = "计时机制",
+				text = {
+					"带有{C:attention}时间相关{}效果的物品及机制",
+				},
+			},
+			set_cry_voucher = {
+				name = "杂项优惠券",
+				text = {
+					"Cryptid新增的1阶和2阶{C:attention}优惠券{}",
 				},
 			},
 		},
@@ -833,7 +1181,7 @@ return {
 				label = "易碎",
 				name = "灰质琉璃",
 				text = {
-					"{C:white,X:mult} X#3# {} 倍率",
+					"{C:white,X:mult} X#3# {}倍率",
 					"触发时{C:green}#1# / #2#{} 的概率不会被摧毁",
 				},
 			},
@@ -862,13 +1210,13 @@ return {
 			e_cry_mosaic = {
 				name = "马赛克",
 				text = {
-					"{X:chips,C:white} X#1# {} 筹码",
+					"{X:chips,C:white} X#1# {}筹码",
 				},
 			},
 			e_cry_noisy = {
 				name = "噪声",
 				text = {
-					"   ",
+					"???",
 				},
 			},
 			e_cry_oversat = {
@@ -885,7 +1233,7 @@ return {
 				text = {
 					"当计分时",
 					"{C:green}#2# / #3#{} 几率",
-					"{C:attention}重新触发{} #1# 次",
+					"{C:attention}重新触发{}#1#次",
 				},
 			},
 			m_cry_light = {
@@ -897,8 +1245,44 @@ return {
 					"{C:inactive}(当前 {X:mult,C:white}X#2#{C:inactive} 倍率)",
 				},
 			},
+			m_cry_abstract = {
+				name = "抽象牌",
+				text = {
+					"{X:dark_edition,C:white}^#1#{}倍率，",
+					"算作{C:attention}自身{}的点数和花色",
+					"在{C:attention}回合结束{}或{C:attention}出牌{}时",
+					"有{C:green}#4#/#5#{}概率{C:red,E:2}摧毁{}此牌",
+				},
+			},
 		},
 		Joker = {
+			j_cry_test_modest = {
+				name = "测试小丑",
+				text = {
+					"{C:chips}+#1#{}筹码",
+				},
+			},
+			j_cry_test_mainline = {
+				name = "测试小丑",
+				text = {
+					"{C:chips}+#1#{}筹码",
+					"在{C:attention}盲注{}开始时获得{C:money}+$44{}",
+				},
+			},
+			j_cry_test_madness = {
+				name = "测试小丑",
+				text = {
+					"{C:chips}+#1#{}筹码",
+					"在{C:attention}盲注{}开始时获得{C:money}+$44444{}",
+				},
+			},
+			j_cry_test_cryptid_in_2025 = {
+				name = "测试小丑",
+				text = {
+					"{C:chips}+#1#{}筹码",
+					"在{C:attention}盲注{}开始时获得{C:money}+$44444{}",
+				},
+			},
 			j_cry_CodeJoker = {
 				name = "代码小丑",
 				text = {
@@ -915,6 +1299,14 @@ return {
 					"{C:inactive,s:0.8}(增长为 +1, +2, +3)",
 				},
 			},
+			["j_cry_Double Scale_modest"] = {
+				name = "双重天平",
+				text = {
+					"成长性{C:attention}小丑{}",
+					"以{C:attention}两倍{}速度增长",
+					'{C:inactive,s:0.8}"这叫双重天平，不是平方天平！"',
+				},
+			},
 			j_cry_M = {
 				name = "M",
 				text = {
@@ -927,8 +1319,8 @@ return {
 				name = "M蛋",
 				text = {
 					"出售这张小丑来创造",
-					"{C:attention}#2#{} 张开心小丑",
-					"在回合结束时增加 {C:attention}#1#{}",
+					"{C:attention}#2#{}张开心小丑",
+					"在回合结束时增加{C:attention}#1#{}",
 				},
 			},
 			j_cry_Scalae = {
@@ -953,8 +1345,16 @@ return {
 				name = "怀旧 Googol 游戏牌",
 				text = {
 					"出售此牌以复制",
-					"{C:attention}2{} 张最左侧的小丑",
+					"{C:attention}2{}张最左侧的小丑",
 					"{C:inactive,s:0.8}不会复制怀旧 Googol 游戏牌{}",
+				},
+			},
+			j_cry_altgoogol_balanced = {
+				name = "怀旧 Googol 游戏牌",
+				text = {
+					"出售此卡以复制最左侧小丑{C:attention}#1#{}次",
+					"{C:inactive,s:0.8}不复制怀旧谷歌牌{}",
+					"{C:inactive}（必须有空间）",
 				},
 			},
 			j_cry_antennastoheaven = {
@@ -969,7 +1369,7 @@ return {
 			j_cry_apjoker = {
 				name = "AP 弹小丑",
 				text = {
-					"对boss盲注提供{X:mult,C:white} X#1# {} 倍率",
+					"对boss盲注提供{X:mult,C:white} X#1# {}倍率",
 				},
 			},
 			j_cry_arsonist = {
@@ -979,23 +1379,39 @@ return {
 			j_cry_astral_bottle = {
 				name = "瓶中星球",
 				text = {
-					"当出售时, 应用 {C:dark_edition}星界{}",
-					"和{C:attention}易腐{} 到一张",
-					"随机的 {C:attention}小丑牌{}",
+					"当出售时, 应用{C:dark_edition}星界{}",
+					"和{C:attention}易腐{}到一张",
+					"随机的{C:attention}小丑牌{}",
+				},
+			},
+			j_cry_astral_bottle_mainline = {
+				name = "瓶中星球",
+				text = {
+					"当出售时, 应用{C:dark_edition}星界{}",
+					"和{C:attention}易腐{}到一张",
+					"随机的{C:attention}小丑牌{}",
+				},
+			},
+			j_cry_astral_bottle_madness = {
+				name = "瓶中星球",
+				text = {
+					"当出售时, 应用{C:dark_edition}星界{}",
+					"和{C:attention}易腐{}到一张",
+					"到一张随机的{C:attention}小丑牌{}",
 				},
 			},
 			j_cry_big_cube = {
 				name = "大大方块",
 				text = {
-					"{X:chips,C:white} X#1# {} 筹码",
+					"{X:chips,C:white} X#1# {}筹码",
 				},
 			},
 			j_cry_biggestm = {
 				name = "超大M",
 				text = {
-					"{X:mult,C:white} X#1# {} 倍率直到本轮结束",
-					"如果 {C:attention}打出牌型{}",
-					"是一个 {C:attention}#2#{}",
+					"{X:mult,C:white} X#1# {}倍率直到本轮结束",
+					"如果{C:attention}打出牌型{}",
+					"是一个{C:attention}#2#{}",
 					"{C:inactive}(当前 {C:attention}#3#{}{C:inactive}){}",
 					"{C:inactive,s:0.8}不是胖，只是骨架大。",
 				},
@@ -1004,7 +1420,7 @@ return {
 				name = "黑名单",
 				text = {
 					"当手牌中有或者打出{C:attention}#1#{}时",
-					"{C:chips}筹码{} 和 {C:mult}倍率{} 变为0",
+					"{C:chips}筹码{}和{C:mult}倍率{}变为0",
 					"如果牌组中没有{C:attention}#1#{}，自毁",
 					"{C:inactive,s:0.8}不会改变牌型等级",
 				},
@@ -1013,7 +1429,7 @@ return {
 				name = "Blender",
 				text = {
 					"使用{C:cry_code}代码牌{}时",
-					"获得一张 {C:attention}随机{}消耗牌",
+					"获得一张{C:attention}随机{}消耗牌",
 				},
 			},
 			j_cry_blurred = {
@@ -1034,7 +1450,7 @@ return {
 			j_cry_bonkers = {
 				name = "癫狂小丑",
 				text = {
-					"如果出的牌中包含",
+					"如果打出的牌中包含",
 					"一个 {C:attention}#2#",
 					"{C:red}+#1#{} 倍率",
 				},
@@ -1051,22 +1467,26 @@ return {
 			j_cry_booster = {
 				name = "补充包小丑",
 				text = {
-					"商店{C:attention}+#1#{} 补充包槽位",
+					"商店{C:attention}+#1#{}补充包槽位",
 				},
 			},
 			j_cry_boredom = {
 				name = "无聊小丑",
 				text = {
 					"{C:green}#1# / #2#{} 概率",
-					"率重新触发{C:attention}所有小丑牌{}和{C:attention}计分牌{}",
+					"重新触发{C:attention}所有小丑牌{}和{C:attention}计分牌{}",
 					"{C:inactive,s:0.8}无法触发{C:attention}无聊小丑{}{}",
+				},
+				unlock = {
+					"在标题界面",
+					"挂机{C:attention}10分钟",
 				},
 			},
 			j_cry_brittle = {
 				name = "脆脆糖",
 				text = {
-					"之后 {C:attention}#1#{} 次出牌,",
-					"随机添加 {C:attention}石头{}, {C:attention}黄金{}, 或 {C:attention}钢铁{}增强到最右边的记分牌",
+					"之后{C:attention}#1#{}次出牌,",
+					"随机添加{C:attention}石头{},{C:attention}黄金{},或{C:attention}钢铁{}增强到最右边的记分牌",
 				},
 			},
 			j_cry_bubblem = {
@@ -1081,42 +1501,49 @@ return {
 				name = "巴士司机",
 				text = {
 					"{C:green}#1# / #3#{} 概率 {C:mult}+#2#{} 倍率",
-					"或{C:green}1 /4{} 概率 {C:mult}-#2#{} 倍率",
+					"或{C:green}#4# / #3#{} 概率 {C:mult}-#2#{} 倍率",
+				},
+			},
+			j_cry_buttercup = {
+				name = "毛茛",
+				text = {
+					"可储存{C:attention}#1#{}个选中的商店物品",
+					"出售时：将储存的物品添加到下一个商店",
 				},
 			},
 			j_cry_candy_basket = {
 				name = "糖果篮子",
 				text = {
-					"卖掉这张牌获得 {C:attention}#1#{} {C:cry_candy}张糖果",
-					" 每击败 {C:attention}2{} 个盲注{C:attention}+#2#{} {C:cry_candy}糖果{}",
-					"击败{C:attention}Boss 盲注{}{C:attention}+#3#{} {C:cry_candy}糖果{}",
+					"卖掉这张牌获得{C:attention}#1#{}{C:cry_candy}张糖果",
+					"每击败{C:attention}2{}个盲注{C:attention}+#2#{}{C:cry_candy}糖果{}",
+					"击败{C:attention}Boss 盲注{}{C:attention}+#3#{}{C:cry_candy}糖果{}",
 				},
 			},
 			j_cry_candy_buttons = {
 				name = "纽扣糖",
 				text = {
-					"之后的 {C:attention}#1#{} 次重掷",
-					"只花 {C:money}$1{}",
+					"之后的{C:attention}#1#{}次重掷",
+					"只花{C:money}$1{}",
 				},
 			},
 			j_cry_candy_cane = {
 				name = "拐杖糖",
 				text = {
-					"之后 {C:attention}#1#{} 回合",
-					" 打出的牌被{C:attention}重新触发{}时获得{C:money}$#2#",
+					"之后{C:attention}#1#{}回合",
+					"打出的牌被{C:attention}重新触发{}时获得{C:money}$#2#",
 				},
 			},
 			j_cry_candy_dagger = {
 				name = "糖果匕首",
 				text = {
-					"选择 {C:attention}盲注{} 后",
-					"摧毁它左边的小丑,创造一张{C:cry_candy}糖果{}小丑",
+					"选择{C:attention}盲注{}后",
+					"摧毁它右边的小丑,创造一张{C:cry_candy}糖果{}小丑",
 				},
 			},
 			j_cry_candy_sticks = {
 				name = "棒棒糖",
 				text = {
-					"直到你打出 {C:attention}#1#{} 手牌",
+					"直到你打出{C:attention}#1#{}手牌",
 					"下个Boss盲注的效果失效",
 				},
 			},
@@ -1126,13 +1553,38 @@ return {
 					"右侧每有一张{C:blue}稀有度高于普通{}的小丑",
 					"所有左侧的小丑{C:attention}重新触发{}{C:attention}一次{}",
 				},
+				unlock = {
+					"在一手牌中",
+					"重新触发{C:attention}小丑{}",
+					"{C:attention}114次",
+				},
+			},
+			j_cry_canvas_balanced = {
+				name = "画布",
+				text = {
+					"右侧每有一张{C:blue}稀有度高于普通{}的小丑",
+					"所有左侧的小丑{C:attention}重新触发{}{C:attention}一次{}",
+					"{C:inactive}(最多2次重新触发)",
+				},
+				unlock = {
+					"在一手牌中",
+					"重新触发{C:attention}小丑{}",
+					"{C:attention}114次",
+				},
 			},
 			j_cry_caramel = {
 				name = "焦糖",
 				text = {
 					"每打出一张牌时",
-					"在得分时获得 {X:mult,C:white}X#1#{} 倍率",
-					"持续 {C:attention}#2#{} 回合",
+					"在得分时获得{X:mult,C:white}X#1#{}倍率",
+					"持续{C:attention}#2#{}回合",
+				},
+			},
+			j_cry_cat_owl = {
+				name = "猫头鹰",
+				text = {
+					"{C:attention}幸运牌{}同时算作{C:attention}回响牌",
+					"{C:attention}回响牌{}同时算作{C:attention}幸运牌",
 				},
 			},
 			j_cry_chad = {
@@ -1146,7 +1598,7 @@ return {
 				name = "辣椒",
 				text = {
 					"回合结束时",
-					"这个小丑获得{X:mult,C:white} X#2# {} 倍率",
+					"这个小丑获得{X:mult,C:white} X#2# {}倍率",
 					"{C:attention}#3#{}回合后自毁",
 					"(当前{X:mult,C:white} X#1# {C:inactive}倍率)",
 				},
@@ -1155,7 +1607,7 @@ return {
 				name = "巧克力十面骰",
 				text = {
 					"击败Boss盲注后",
-					"投掷一个{C:green}d10{} 的判定",
+					"投掷一个{C:green}d10{}的判定",
 					"去开始一个{C:cry_ascendant,E:1}事件{}",
 					"{C:inactive}(当前: #1#)",
 				},
@@ -1164,7 +1616,7 @@ return {
 				name = "环形转轮",
 				text = {
 					"{X:dark_edition,C:white}^#1#{} 筹码, {X:dark_edition,C:white}^#1#{} 倍率",
-					"如果{C:attention}正好{}剩余 #2#",
+					"如果{C:attention}正好{}剩余#2#",
 					"手牌",
 				},
 			},
@@ -1176,20 +1628,72 @@ return {
 					"{C:legendary}传奇{}小丑每个提供 {X:mult,C:white} X#3# {} 倍率",
 					"{C:cry_exotic}域外{}小丑每个提供 {X:mult,C:white} X#4# {} 倍率",
 				},
+				unlock = {
+					"在{C:attention}底注9{}前获得",
+					"{C:red}稀有{}、{C:cry_epic}史诗{}和{C:legendary}传奇{}小丑",
+				},
 			},
 			j_cry_clash = {
 				name = "冲突",
 				text = {
 					"如果打出的手牌包含",
-					"一个 {C:attention}#2#",
-					"{X:mult,C:white} X#1# {} 倍率",
+					"一个{C:attention}#2#",
+					"{X:mult,C:white} X#1# {}倍率",
+				},
+				unlock = {
+					"赢得一局游戏",
+					"且最终打出的牌型为",
+					"{E:1,C:attention}至尊对子",
+				},
+			},
+			j_cry_the = {
+				name = " ",
+				text = {
+					"如果打出的手牌是{C:attention}#2#",
+					"{X:mult,C:white} X#1# {}倍率",
+				},
+				unlock = {
+					"赢得一局游戏",
+					"且最终打出的牌型为",
+					"{E:1,C:attention}None",
 				},
 			},
 			j_cry_clicked_cookie = {
 				name = "被点击的饼干",
 				text = {
 					"{C:chips}+#1#{} 筹码",
-					"每当该小丑被{C:attention}点击{}时，{C:chips}-#2#{} 筹码",
+					"每次鼠标{C:attention}点击{}后，{C:chips}-#2#{} 筹码",
+				},
+			},
+			j_cry_clockwork = {
+				name = "发条小丑",
+				text = {
+					"每打出{C:attention}#9#{}{C:inactive}(#1#){}手牌重新触发持有的钢铁牌",
+					"每打出{C:attention}#10#{}{C:inactive}(#2#){}手牌获得{X:mult,C:white}X#6#{}(当前X#5#)倍率",
+					"每打出{C:attention}#11#{}{C:inactive}(#3#){}手牌将第一张打出的牌变为钢铁牌",
+					"每打出{C:attention}#12#{}{C:inactive}(#4#){}手牌使持有的钢铁牌提供+{X:mult,C:white}X#8#{}(当前X#7#)倍率",
+				},
+			},
+			j_cry_CodeJoker = {
+				name = "代码小丑",
+				text = {
+					"选择{C:attention}盲注{}时，",
+					"创建一张{C:dark_edition}负片{}{C:cry_code}代码牌{}",
+				},
+				unlock = {
+					"发现所有",
+					"{C:cry_code}代码牌",
+				},
+			},
+			j_cry_CodeJoker_modest = {
+				name = "代码小丑",
+				text = {
+					"选择{C:attention}Boss盲注{}时，",
+					"创建一张{C:dark_edition}负片{}{C:cry_code}代码牌{}",
+				},
+				unlock = {
+					"发现所有",
+					"{C:cry_code}代码牌",
 				},
 			},
 			j_cry_coin = {
@@ -1210,13 +1714,30 @@ return {
 				text = {
 					"使用{C:cry_code}代码牌{}时",
 					"{C:green}#1# / #2#{}概率将其复制回消耗牌槽",
+					"{C:red}每回合最多一次{}",
+					"{C:inactive}(必须有空间)",
+				},
+			},
+			j_cry_copypaste_modest = {
+				name = "复制/粘贴",
+				text = {
+					"复制拉取的{C:cry_code}代码牌{}",
+					"{C:inactive}(必须有空间)",
+				},
+			},
+			j_cry_copypaste_madness = {
+				name = "复制/粘贴",
+				text = {
+					"使用{C:cry_code}代码牌{}时",
+					"{C:green}#1# / #2#{}概率将其复制回消耗牌槽",
+					"{C:inactive}(必须有空间)",
 				},
 			},
 			j_cry_cotton_candy = {
 				name = "棉花糖",
 				text = {
 					"出售后相邻的",
-					"{C:attention}小丑{} 变为 {C:dark_edition}负片{}",
+					"{C:attention}小丑{}变为{C:dark_edition}负片{}",
 				},
 			},
 			j_cry_crustulum = {
@@ -1249,6 +1770,10 @@ return {
 					"{C:dark_edition,E:1}你无法逃脱...{}",
 					"{C:inactive}(必须有槽位){}",
 				},
+				unlock = {
+					"获得一个{C:purple}永恒{}的",
+					"{C:attention}方尖石塔",
+				},
 			},
 			j_cry_cursor = {
 				name = "光标",
@@ -1261,23 +1786,37 @@ return {
 			j_cry_cut = {
 				name = "剪切",
 				text = {
-					"在 {C:attention}离开商店{}时",
-					"这张小丑随机摧毁一张 {C:cry_code}代码牌{}",
-					"并且增加 {X:mult,C:white} X#1# {} 倍率",
+					"在{C:attention}离开商店{}时",
+					"这张小丑随机摧毁一张{C:cry_code}代码牌{}",
+					"并且增加 {X:mult,C:white} X#1# {}倍率",
 					"{C:inactive}(当前已提供{X:mult,C:white} X#2# {C:inactive} 倍率)",
 				},
 			},
 			j_cry_delirious = {
 				name = "错乱小丑",
 				text = {
-					"如果出的牌中包含 {C:attention}#2#",
+					"如果打出的牌中包含{C:attention}#2#",
 					"{C:red}+#1#{} 倍率",
+				},
+			},
+			j_cry_demicolon = {
+				name = "分号",
+				text = {
+					"{C:attention}强制触发{}右侧的小丑",
+				},
+			},
+			j_cry_digitalhallucinations = {
+				name = "数字幻觉",
+				text = {
+					"打开{C:attention}补充包{}时，",
+					"有{C:green}#1#/#2#{}概率创建一张",
+					"与其{C:attention}类型{}对应的随机{C:dark_edition}负片{}牌",
 				},
 			},
 			j_cry_discreet = {
 				name = "低调小丑",
 				text = {
-					"如果出的牌中包含 {C:attention}#2#",
+					"如果打出的牌中包含{C:attention}#2#",
 					"{C:chips}+#1#{} 筹码",
 				},
 			},
@@ -1285,38 +1824,49 @@ return {
 				name = "涂鸦 M",
 				text = {
 					"当{C:attention}选择盲注{}时",
-					"创造2个随机{C:dark_edition}负片{} {C:attention}消耗牌{}",
+					"创造2个随机{C:dark_edition}负片{}{C:attention}消耗牌{}",
 					"每有1个{C:attention}开心小丑{}创造1个额外的{C:attention}消耗牌",
 				},
 			},
 			j_cry_dropshot = {
 				name = "一杆入洞",
 				text = {
-					"出牌时,每有一张 {C:attention}不计分{}的 {V:1}#2#{}牌",
-					"这张小丑牌增加 {X:mult,C:white} X#1# {} 倍率",
+					"出牌时,每有一张{C:attention}不计分{}的{V:1}#2#{}牌",
+					"这张小丑牌增加{X:mult,C:white} X#1# {}倍率",
 					"花色每回合改变",
 					"{C:inactive}(当前 {X:mult,C:white} X#3# {C:inactive} 倍率)",
+				},
+				unlock = {
+					"打出一手{C:attention}高牌{}，",
+					"其中包含{C:attention}4张{}",
+					"同花色的牌",
 				},
 			},
 			j_cry_dubious = {
 				name = "可疑小丑",
 				text = {
-					"如果出的牌中包含 {C:attention}#2#",
+					"如果打出的牌中包含{C:attention}#2#",
 					"{C:chips}+#1#{} 筹码",
 				},
 			},
 			j_cry_duos = {
 				name = "双重奏",
 				text = {
-					"{X:mult,C:white} X#1# {} 倍率如果出牌",
+					"{X:mult,C:white} X#1# {}倍率如果出牌",
 					"手牌包含{C:attention}#2#",
+				},
+				unlock = {
+					"赢一局",
+					"且不打出",
+					"{C:attention}两对{}",
 				},
 			},
 			j_cry_duplicare = {
 				name = "复制",
 				text = {
-					"每张{C:attention}小丑牌{}给予",
-					"{X:dark_edition,C:white}^#1#{} 倍率",
+					"当一张{C:attention}小丑{}或手牌计分时",
+					"这个小丑获得{X:mult,C:white} X#2# {}倍率",
+					"{C:inactive}(当前{X:mult,C:white} X#1# {C:inactive}倍率)",
 				},
 			},
 			j_cry_effarcire = {
@@ -1341,7 +1891,7 @@ return {
 				name = "王牌均衡",
 				text = {
 					"小丑牌以{C:attention}收藏{}中的顺序出现",
-					"出牌时创造{C:attention}#1#{} {C:dark_edition}负片{}小丑",
+					"出牌时创造{C:attention}#1#{}张{C:dark_edition}负片{}小丑",
 					"不会出现{C:cry_exotic,s:0.8}域外{C:inactive,s:0.8}或更稀有的小丑",
 					"{s:0.8}最后生成的小丑: {C:attention,s:0.8}#2#",
 				},
@@ -1355,23 +1905,31 @@ return {
 			j_cry_eternalflame = {
 				name = "永恒之火",
 				text = {
-					"每出售一张牌，",
-					"这张小丑获得{X:mult,C:white} X#1# {} 倍率",
+					"每{C:attention}出售{}一张售价至少为{C:money}$3{}的牌，",
+					"这张小丑获得{X:mult,C:white} X#1# {}倍率",
+					"(当前{X:mult,C:white} X#2# {C:inactive}倍率)",
+				},
+			},
+			j_cry_eternalflame2 = {
+				name = "永恒之火",
+				text = {
+					"每{C:attention}出售{}一张牌，",
+					"这张小丑获得{X:mult,C:white} X#1# {}倍率",
 					"(当前{X:mult,C:white} X#2# {C:inactive}倍率)",
 				},
 			},
 			j_cry_exoplanet = {
 				name = "系外行星",
 				text = {
-					"每张{C:dark_edition}镭射{}卡提供{C:mult}+#1#{} 倍率",
+					"每张{C:dark_edition}镭射{}卡提供{C:mult}+#1#{}倍率",
 				},
 			},
 			j_cry_exponentia = {
 				name = "指数",
 				text = {
-					"触发 {X:red,C:white} X 倍率 {} 时",
-					"这张小丑获得 {X:dark_edition,C:white} ^#1# {} 倍率",
-					"{C:inactive}(当前 {X:dark_edition,C:white} ^#2# {C:inactive} 倍率)",
+					"触发{X:red,C:white}X倍率{}时",
+					"这张小丑获得{X:dark_edition,C:white} ^#1# {}倍率",
+					"{C:inactive}(当前 {X:dark_edition,C:white} ^#2# {C:inactive}倍率)",
 				},
 			},
 			j_cry_exposed = {
@@ -1379,31 +1937,68 @@ return {
 				text = {
 					"重新触发{C:attention}非人头牌{} ",
 					"额外{C:attention}#1#{}次",
-					"所有 {C:attention}人头牌{} 都被削弱",
+					"所有{C:attention}人头牌{}都被削弱",
+				},
+			},
+			j_cry_eyeofhagane = {
+				name = "叶钢之眼",
+				text = {
+					"所有打出的{C:attention}人头牌{}",
+					"计分时变为{C:attention}钢铁{}牌",
+				},
+			},
+			j_cry_highfive = {
+				name = "击掌",
+				text = {
+					"如果最高{C:attention}计分点数{}是{C:attention}5{}，",
+					"将所有计分牌转换为{C:attention}5{}",
+					"{s:0.8,C:inactive}A算作1",
 				},
 			},
 			j_cry_facile = {
 				name = "简易",
 				text = {
-					"{C:attention}#2#{} 张及以下的牌得分",
-					"{X:dark_edition,C:white}^#1#{} 倍率",
+					"{C:attention}#2#{}张及以下的牌得分",
+					"{X:dark_edition,C:white}^#1#{}倍率",
 					"(重复触发算作多张)",
+				},
+			},
+			j_cry_fading_joker = {
+				name = "褪色小丑",
+				text = {
+					"当一张{C:attention}易腐{}牌被削弱时，",
+					"此小丑获得{X:mult,C:white}X#1#{}倍率",
+					"{C:inactive}(当前{} {X:mult,C:white}X#2#{} {C:inactive}倍率){}",
+				},
+			},
+			j_cry_familiar_currency = {
+				name = "熟悉货币",
+				text = {
+					"回合结束时创建一张{C:attention}梗小丑{}",
+					"消耗{C:money}$#1#{}（如果可能）",
+					"{C:inactive}（必须有空间）",
 				},
 			},
 			j_cry_filler = {
 				name = "填充物",
 				text = {
 					"",
-					"如果出的牌中包含{C:attention}#2# 提供{X:mult,C:white} X#1# {} 倍率",
+					"如果打出的牌中包含{C:attention}#2#",
+					"提供{X:mult,C:white} X#1# {}倍率",
+				},
+				unlock = {
+					"赢一局",
+					"且不打出",
+					"{C:attention}高牌{}",
 				},
 			},
 			j_cry_fleshpanopticon = {
 				name = "血肉监牢",
 				text = {
-					"{C:attention}Boss 盲注{} 得分需求 {C:red}X#1#{}",
-					"当 {C:attention}Boss 盲注{} 被击败后,",
+					"{C:attention}Boss 盲注{}得分需求{C:red}X#1#{}",
+					"当{C:attention}Boss 盲注{}被击败后,",
 					"{C:red}自毁{}, 然后创建",
-					"一张 {C:dark_edition}负片{} {C:spectral}真理之门{} ",
+					"一张{C:dark_edition}负片{}{C:spectral}真理之门{} ",
 					"{C:inactive,s:0.8}此等监牢……囚禁于吾？",
 				},
 			},
@@ -1419,7 +2014,7 @@ return {
 				name = "M当劳",
 				text = {
 					"{C:mult}+#1#{} 倍率",
-					"在 {C:attention}#2#{} 回合中{C:red,E:2}自毁{}",
+					"在 {C:attention}#2#{}回合中{C:red,E:2}自毁{}",
 					"当{C:attention}开心小丑{}被{C:attention}出售{}时增加{C:attention}#3#{}回合",
 					"{C:inactive,s:0.8}2 双层芝士，2 麦香鸡{}",
 					"{C:inactive,s:0.8}1 大薯条，20 大蛋糕{}",
@@ -1429,30 +2024,41 @@ return {
 				name = "鲁莽小丑",
 				text = {
 					"如果打出的手牌包含",
-					"一个 {C:attention}#2#",
-					"{C:red}+#1#{} 倍率",
+					"一个{C:attention}#2#",
+					"{C:red}+#1#{}倍率",
+				},
+			},
+			j_cry_undefined = {
+				name = "未定义小丑",
+				text = {
+					"{C:red}+#1#{}倍率",
+					"如果出牌是{C:attention}#2#",
 				},
 			},
 			j_cry_formidiulosus = {
 				name = "驱邪",
 				text = {
-					"获得 {X:cry_cursed,C:white}诅咒{} 小丑时，将其摧毁",
-					"离开商店时创造 {C:attention}#1#{}张 {C:dark_edition}负片{C:cry_candy}糖果{} ",
-					"每有一张 {C:cry_candy}糖果{}小丑,{X:dark_edition,C:white}+^#2#{} 倍率",
+					"获得{X:cry_cursed,C:white}诅咒{}小丑时，将其摧毁",
+					"离开商店时创造{C:attention}#1#{}张{C:dark_edition}负片{C:cry_candy}糖果{} ",
+					"每有一张{C:cry_candy}糖果{}小丑,{X:dark_edition,C:white}+^#2#{} 倍率",
 					"{C:inactive}(当前 {X:dark_edition,C:white}^#3#{C:inactive} 倍率)",
 				},
 			},
 			j_cry_foxy = {
 				name = "奸猾小丑",
 				text = {
-					"如果出的牌中包含 {C:attention}#2#",
-					"{C:chips}+#1#{} 筹码",
+					"如果打出的牌中包含{C:attention}#2#",
+					"{C:chips}+#1#{}筹码",
 				},
 			},
 			j_cry_fractal = {
 				name = "分形手指",
 				text = {
-					"{C:attention}+#1#{} 手牌选择上限",
+					"{C:attention}+#1#{}手牌选择上限",
+				},
+				unlock = {
+					"打出一手{C:attention}同花顺{}",
+					"但该{C:attention}顺子{}不是{C:attention}同花",
 				},
 			},
 			j_cry_fspinner = {
@@ -1467,15 +2073,15 @@ return {
 				name = "烂逼小丑",
 				text = {
 					"如果打出的手牌包含",
-					"一个 {C:attention}#2#",
+					"一个{C:attention}#2#",
 					"{C:red}+#1#{} 倍率",
 				},
 			},
 			j_cry_gardenfork = {
 				name = "7-1 小径分岔的花园",
 				text = {
-					"打出的{C:attention} A{} 和{C:attention} 7{}",
-					"会在被计分时+{C:money}$#1#{} 块钱",
+					"打出的{C:attention}A{}和{C:attention}7{}",
+					"会在被计分时+{C:money}$#1#{}块钱",
 					"{C:inactive,s:0.8}（一本书名，同时也捏他ultrakill关卡名）",
 				},
 			},
@@ -1493,14 +2099,14 @@ return {
 				text = {
 					"回合结束后",
 					"{C:green}#1# / #2#{} 几率 ",
-					"{C:attention}作祟{} 一张随机的 {C:attention}小丑",
-					"{C:green}#1# / #3#{} 几率{E:2,C:red}自毁 {}",
+					"{C:attention}作祟{}一张随机的{C:attention}小丑",
+					"{C:green}#1# / #3#{} 几率{E:2,C:red}自毁{}",
 				},
 			},
 			j_cry_giggly = {
 				name = "荒谬小丑",
 				text = {
-					"如果出的牌中包含 {C:attention}#2#",
+					"如果打出的牌中包含{C:attention}#2#",
 					"{C:red}+#1#{} 倍率",
 				},
 			},
@@ -1516,7 +2122,11 @@ return {
 				name = "Googol 游戏牌",
 				text = {
 					"{C:green}#1# / #2#{} 概率提供",
-					"{X:red,C:white} X#3# {} 倍率",
+					"{X:red,C:white} X#3# {}倍率",
+				},
+				unlock = {
+					"在一次出牌中",
+					"获得至少{C:attention}1.0e100{}筹码",
 				},
 			},
 			j_cry_happy = {
@@ -1532,7 +2142,7 @@ return {
 				name = "快乐之家",
 				text = {
 					"{X:dark_edition,C:white}^#1#{} 倍率当",
-					" {C:attention}114{} 次出牌{}后",
+					" {C:attention}114{}次出牌{}后",
 					"{C:inactive}(当前 #2#/114){}",
 					"{C:inactive,s:0.8}没有地方能比得上家!{}",
 				},
@@ -1540,9 +2150,14 @@ return {
 			j_cry_home = {
 				name = "家园",
 				text = {
-					"{X:mult,C:white} X#1# {} 倍率",
+					"{X:mult,C:white} X#1# {}倍率",
 					"如果打出的手牌包含",
 					"一个{C:attention}#2#",
+				},
+				unlock = {
+					"赢一局",
+					"且不打出",
+					"{C:attention}葫芦{}",
 				},
 			},
 			j_cry_hunger = {
@@ -1552,17 +2167,24 @@ return {
 					"获得{C:money}$#1#{}",
 				},
 			},
+			j_cry_huntingseason = {
+				name = "狩猎季节",
+				text = {
+					"如果打出的手牌正好有{C:attention}3张{}牌，",
+					"计分后{C:red}摧毁{}中间的牌",
+				},
+			},
 			j_cry_iterum = {
 				name = "再触",
 				text = {
 					"已经出过的牌重新触发{C:attention}#2#{}次",
-					"并且每张牌提供{X:mult,C:white} X#1# {} 倍率",
+					"并且每张牌提供{X:mult,C:white} X#1# {}倍率",
 				},
 			},
 			j_cry_jawbreaker = {
 				name = "硬糖",
 				text = {
-					"击败 {C:attention}Boss 盲注后{} ,",
+					"击败{C:attention}Boss 盲注后{} ,",
 					"让所有小丑数值变为{C:attention}两倍{} ",
 					"{E:2,C:red}自毁{}",
 				},
@@ -1572,8 +2194,12 @@ return {
 				text = {
 					"{C:attention}连续{}打出",
 					"{C:attention}使用次数最多的牌型{}时",
-					"获得 {X:mult,C:white} X#1# {} 倍率",
+					"获得{X:mult,C:white} X#1# {}倍率",
 					"{C:inactive}(当前{X:mult,C:white} X#2# {C:inactive}倍率)",
+				},
+				unlock = {
+					"仅使用{C:attention}单一类型的{}",
+					"{C:attention}扑克手牌{}赢得一局",
 				},
 			},
 			j_cry_jollysus = {
@@ -1585,19 +2211,35 @@ return {
 					"{C:inactive}#1#{}",
 				},
 			},
+			j_cry_jtron = {
+				name = "吉姆波创9000",
+				text = {
+					"每个默认{C:attention}小丑{}使此小丑获得{X:dark_edition,C:white}^#1#{}倍率",
+					"{C:inactive}（当前{X:dark_edition,C:white}^#2#{}倍率）",
+				},
+			},
 			j_cry_kidnap = {
 				name = "绑架",
 				text = {
 					"{C:red}Outdated Description{}",
 					"每回合结尾获得{C:money}$#2#{}",
-					"每卖掉一张{C:attention}倍率{}或者{C:attention}筹码{}小丑时",
+					"每卖掉一张不同的{C:attention}倍率{}或者{C:attention}筹码{}小丑时",
 					"增加{C:money}$#1#{}",
+					"{C:inactive}(当前{C:money}$#2#{C:inactive})",
+				},
+			},
+			j_cry_kittyprinter = {
+				name = "猫咪打印机",
+				text = {
+					"{X:mult,C:white}X#1#{}倍率",
+					"所有{C:attention}跳过{}标签",
+					"变为{C:attention}猫咪标签{}",
 				},
 			},
 			j_cry_kooky = {
 				name = "怪诞小丑",
 				text = {
-					"如果出的牌中包含 {C:attention}#2#",
+					"如果打出的牌中包含{C:attention}#2#",
 					"{C:red}+#1#{} 倍率",
 				},
 			},
@@ -1615,11 +2257,26 @@ return {
 					"当击败{C:attention}Boss 盲注{}时",
 					"使一张随机{C:attention}小丑{}获得{C:dark_edition}多彩{}版本",
 				},
+				unlock = {
+					"击败一个{C:attention}Boss盲注{}",
+					"同时拥有{C:attention}5{}张或更多",
+					"{C:attention}特殊版本卡牌{}或",
+					"{C:attention}小丑牌{}",
+				},
+			},
+			j_cry_lebaron_james = {
+				name = "勒布朗·詹姆斯",
+				text = {
+					"打出并计分的{C:attention}K{}会使本回合",
+					"手牌上限增加{C:attention}+#1#{}",
+					"并触发{C:attention}留在手牌中{}的效果",
+					"{C:inactive}(当前为{}{C:attention}+#2#{}{C:inactive})",
+				},
 			},
 			j_cry_lightupthenight = {
 				name = "7-2 掌灯破暗",
 				text = {
-					"每张 {C:attention}7 {}或 {C:attention}2{}，",
+					"每张 {C:attention}7{}或{C:attention}2{}",
 					"在计分时提供{X:mult,C:white}X#1#{}倍率",
 					"{C:inactive,s:0.8}（捏他ultrakill关卡名）",
 				},
@@ -1629,7 +2286,7 @@ return {
 				text = {
 					"在回合结束时",
 					"给未来的",
-					"这张小丑牌 {X:mult,C:white}X#1#{} 倍率",
+					"这张小丑牌{X:mult,C:white}X#1# {}倍率",
 					"{C:inactive}(当前 {X:mult,C:white}X#2#{C:inactive} 倍率){}",
 				},
 			},
@@ -1646,22 +2303,22 @@ return {
 				name = "幸运小丑",
 				text = {
 					"{C:attention}幸运牌{}成功触发时",
-					"+ {C:money}$#1#{}",
+					"+{C:money}$#1#{}",
 				},
 			},
 			j_cry_luigi = {
 				name = "路易吉",
 				text = {
 					"所有小丑提供",
-					"{X:chips,C:white} X#1# {} 筹码",
+					"{X:chips,C:white} X#1# {}筹码",
 				},
 			},
 			j_cry_m = {
 				name = "m",
 				text = {
 					"当{C:attention}开心小丑{}被售出时",
-					"这张小丑获得 {X:mult,C:white} X#1# {} 倍率",
-					"{C:inactive}(当前 {X:mult,C:white} X#2# {C:inactive} 倍率)",
+					"这张小丑获得 {X:mult,C:white} X#1# {}倍率",
+					"{C:inactive}(当前 {X:mult,C:white} X#2# {C:inactive}倍率)",
 				},
 			},
 			j_cry_macabre = {
@@ -1675,14 +2332,14 @@ return {
 				name = "冰箱磁铁",
 				text = {
 					"回合结束时获得{C:money}$#1#{} ",
-					"如果有少于或等于{C:attention}#3#{} 张小丑牌，获得 {X:money,C:white} X#2# {}",
+					"如果有少于或等于{C:attention}#3#{}张小丑牌，获得{X:money,C:white} X#2#{}",
 					"",
 				},
 			},
 			j_cry_manic = {
 				name = "狂躁小丑",
 				text = {
-					"如果出的牌中包含 {C:attention}#2#",
+					"如果打出的牌中包含{C:attention}#2#",
 					"{C:red}+#1#{} 倍率",
 				},
 			},
@@ -1696,15 +2353,19 @@ return {
 			j_cry_mask = {
 				name = "面具",
 				text = {
-					"{C:attention}人头牌{}额外触发 {C:attention}#1#{} 次",
+					"{C:attention}人头牌{}额外触发{C:attention}#1#{}次",
 					"所有{C:attention}非人头牌{}被削弱",
 				},
 			},
 			j_cry_maximized = {
 				name = "速度拉满",
 				text = {
-					"所有{C:attention}人头牌{}都当作是{C:attention}K{}，",
-					"所有{C:attention}数字牌{}都当作是{C:attention}10s{}，",
+					"所有{C:attention}人头牌{}都当作是{C:attention}K{}",
+					"所有{C:attention}数字牌{}都当作是{C:attention}10s{}",
+				},
+				unlock = {
+					"打出一手{C:attention}五张同花{}",
+					"且都是{C:attention}K{}",
 				},
 			},
 			j_cry_maze = {
@@ -1718,24 +2379,33 @@ return {
 				name = "南瓜糖",
 				text = {
 					"卖掉这张牌",
-					"所有的{C:attention}消耗牌{} 售价 {C:attention}X#1#倍",
+					"所有的{C:attention}消耗牌{}售价{C:attention}X#1#倍",
 				},
 			},
 			j_cry_membershipcard = {
 				name = "会员卡",
 				text = {
-					"Cryptid Discord{}中的每个成员提供{X:mult,C:white}X#1#{}  {C:attention}倍率",
-					"{C:inactive}(当前{X:mult,C:white}X#2#{C:inactive} 倍率)",
-					"{C:blue,s:0.7}https://discord.gg/unbalanced{}",
+					"Cryptid Discord{}中的每个成员提供{X:mult,C:white}X#1#{} {C:attention}倍率",
+					"{C:inactive}(当前{X:mult,C:white}X#2#{C:inactive}倍率)",
+					"{C:blue,s:0.7}https://discord.gg/cryptid{}",
 				},
 			},
 			j_cry_membershipcardtwo = {
-				name = "老旧会员卡",
+				name = "老旧会员卡", --Could probably have a diff Name imo
 				text = {
 					"在{C:attention}Cryptid Discord{}中的每个成员",
-					"提供{C:chips}+#1#{} Chips",
-					"{C:inactive}(当前 {C:chips}+#2#{C:inactive} 筹码)",
-					"{C:blue,s:0.7}https://discord.gg/unbalanced{}",
+					"提供{C:chips}+#1#{}筹码",
+					"{C:inactive}(当前 {C:chips}+#2#{C:inactive}筹码)",
+					"{C:blue,s:0.7}https://discord.gg/cryptid{}",
+				},
+			},
+			j_cry_membershipcardtwo_balanced = {
+				name = "老旧会员卡", --Could probably have a diff Name imo
+				text = {
+					"每有{C:attention}8{}名{C:attention}Cryptid Discord{}成员，",
+					"获得{C:chips}+#1#{}筹码",
+					"{C:inactive}(当前为{C:chips}+#2#{C:inactive}筹码)",
+					"{C:blue,s:0.7}https://discord.gg/cryptid{}",
 				},
 			},
 			j_cry_meteor = {
@@ -1757,8 +2427,8 @@ return {
 				name = "蒙德里安",
 				text = {
 					"若回合结束没有使用弃牌",
-					"该小丑获得{X:mult,C:white} X#1# {} 倍率",
-					"{C:inactive}(当前{X:mult,C:white} X#2# {C:inactive} 倍率)",
+					"该小丑获得{X:mult,C:white} X#1# {}倍率",
+					"{C:inactive}(当前{X:mult,C:white} X#2# {C:inactive}倍率)",
 				},
 			},
 			j_cry_monkey_dagger = {
@@ -1776,14 +2446,14 @@ return {
 				text = {
 					"{C:green}#1# / #2#{} 几率",
 					"{C:attention}摧毁{}购买的牌",
-					"并且售出时 {C:attention}金钱减半",
+					"并且售出时{C:attention}金钱减半",
 				},
 			},
 			j_cry_morse = {
 				name = "摩尔斯电码",
 				text = {
-					"在回合结尾获得 {C:money}$#2#{}",
-					"每卖掉一张 {C:attention}增强卡牌{}增加 {C:money}$#1#{}",
+					"在回合结尾获得{C:money}$#2#{}",
+					"每卖掉一张{C:attention}增强卡牌{}增加{C:money}$#1#{}",
 				},
 			},
 			j_cry_mprime = {
@@ -1791,16 +2461,16 @@ return {
 				text = {
 					"每回合结束时",
 					"创造一张{C:attention}M 小丑{}",
-					"每个 {C:attention}开心小丑{}或者{C:attention}M 小丑{} 提供 {X:dark_edition,C:white}^#1#{} 倍率",
-					"每 {C:attention}卖出{}一张 {C:attention}开心小丑{}",
-					"额外提供 {X:dark_edition,C:white}^#2#{}倍率",
+					"每个{C:attention}开心小丑{}或者{C:attention}M 小丑{}提供{X:dark_edition,C:white}^#1#{}倍率",
+					"每{C:attention}卖出{}一张{C:attention}开心小丑{}",
+					"额外提供{X:dark_edition,C:white}^#2#{}倍率",
 					"{C:inactive,s:0.8}(使徒·十三 除外)",
 				},
 			},
 			j_cry_mstack = {
 				name = "堆叠 M",
 				text = {
-					"每出售{C:attention}#2#{} {C:inactive}[#3#]{} {C:attention}开心小丑{}",
+					"每出售{C:attention}#2#{}{C:inactive}[#3#]{}张{C:attention}开心小丑{}",
 					"重新触发所有已打出的牌",
 					"{C:inactive}(当前{}{C:attention:} #1#{}{C:inactive} 次重新触发){}",
 				},
@@ -1817,21 +2487,21 @@ return {
 			j_cry_necromancer = {
 				name = "死灵法师",
 				text = {
-					"当{C:attention}售出{}一张小丑且其售价大于 {C:attention}$0{} 时",
-					"获得一张 {C:attention}本局游戏售出过的{} {C:attention}随机小丑牌{} ",
-					"并将其 {C:attention}售价{} 变为 {C:attention}$0{}",
+					"当{C:attention}售出{}一张小丑且其售价大于{C:attention}$0{}时",
+					"获得一张{C:attention}本局游戏售出过的{}{C:attention}随机小丑牌{} ",
+					"并将其{C:attention}售价{}变为{C:attention}$0{}",
 				},
 			},
 			j_cry_negative = {
 				name = "负片小丑",
 				text = {
-					"{C:dark_edition}+#1#{C:attention} 小丑{} 槽",
+					"{C:dark_edition}+#1#{C:attention} 小丑{}槽",
 				},
 			},
 			j_cry_nice = {
 				name = "nice",
 				text = {
-					"如果出牌包含 {C:attention}6{} 和 {C:attention}9{}",
+					"如果出牌包含{C:attention}6{}和{C:attention}9{}",
 					"筹码{C:chips}+#1#{}",
 					"{C:inactive,s:0.8}nice{}",
 					"",
@@ -1863,7 +2533,7 @@ return {
 			j_cry_number_blocks = {
 				name = "数字块",
 				text = {
-					"在回合结束时获得 {C:money}$#1#{}",
+					"在回合结束时获得{C:money}$#1#{}",
 					"每持有一张{C:attention}#3#{}手牌",
 					"增加{C:money}$#2#{}的奖励，",
 					"每回合卡牌变化",
@@ -1872,15 +2542,20 @@ return {
 			j_cry_nuts = {
 				name = "坚果",
 				text = {
-					"{X:mult,C:white} X#1# {} 倍率如果出牌",
+					"{X:mult,C:white} X#1# {}倍率如果出牌",
 					"手牌包含",
 					"一个{C:attention}#2#",
+				},
+				unlock = {
+					"赢得一局游戏",
+					"且未打出过",
+					"{E:1,C:attention}同花顺",
 				},
 			},
 			j_cry_nutty = {
 				name = "疯癫小丑",
 				text = {
-					"如果出的牌中包含 {C:attention}#2#",
+					"如果打出的牌中包含{C:attention}#2#",
 					"{C:red}+#1#{} 倍率",
 				},
 			},
@@ -1888,7 +2563,7 @@ return {
 				name = "油灯",
 				text = {
 					"回合结束后",
-					"右边 {C:attention}小丑牌{}的数值 {C:attention}x#1#{}",
+					"右边{C:attention}小丑牌{}的数值{C:attention}x#1#{}",
 				},
 			},
 			j_cry_oldblueprint = {
@@ -1903,13 +2578,13 @@ return {
 				name = "怀旧糖果",
 				text = {
 					"售出这张牌可以永久获得",
-					"{C:attention}+#1#{} 手牌上限",
+					"{C:attention}+#1#{}手牌上限",
 				},
 			},
 			j_cry_oldinvisible = {
 				name = "怀旧隐形小丑",
 				text = {
-					"每卖出 {C:attention} 4 {}张小丑牌，随机复制 {C:attention}一张{}小丑牌",
+					"每卖出{C:attention} 4 {}张小丑牌，随机复制{C:attention}一张{}小丑牌",
 					"无法复制{s:0.8}怀旧隐形小丑{}(当前 #1#/4)",
 					"",
 				},
@@ -1918,6 +2593,13 @@ return {
 				name = "全景监狱",
 				text = {
 					"所有出牌都视为本回合{C:attention}最后一次出牌{}",
+				},
+			},
+			j_cry_paved_joker = {
+				name = "铺路小丑",
+				text = {
+					"石头牌可以填补",
+					"{C:attention}顺子{}和{C:attention}同花{}中{C:attention}#1#{}点的间隔",
 				},
 			},
 			j_cry_penetrating = {
@@ -1931,8 +2613,8 @@ return {
 			j_cry_pickle = {
 				name = "腌黄瓜",
 				text = {
-					"当跳过 {C:attention}盲注{} 时，创造{C:attention}#1#{} 个标签",
-					"当选择 {C:attention}盲注{} 时，则减少{C:red}#2#{} ",
+					"当跳过{C:attention}盲注{}时，创造{C:attention}#1#{}个标签",
+					"当选择{C:attention}盲注{}时，则减少{C:red}#2#{} ",
 				},
 			},
 			j_cry_pirate_dagger = {
@@ -1948,23 +2630,73 @@ return {
 			j_cry_pity_prize = {
 				name = "遗憾奖",
 				text = {
-					"当你跳过 {C:attention}补充包{} 获得一个随机的 {C:attention}标签{}",
+					"当你跳过{C:attention}补充包{}时",
+					"获得一个随机的{C:attention}标签{}",
+				},
+			},
+			j_cry_pity_prize_modest = {
+				name = "遗憾奖",
+				text = {
+					"当跳过一个{C:attention}补充包{}时",
+					"获得一个随机{C:attention}标签{}",
+					"{C:red,E:2}自毁{}",
+				},
+			},
+			j_cry_pizza = {
+				name = "披萨",
+				text = {
+					"在{C:attention}#1#{} {C:inactive}[#2#]{}回合之后，",
+					"出售这个小丑可以创建{C:attention}#3#{}个披萨片",
+				},
+			},
+			j_cry_pizza_slice = {
+				name = "披萨片",
+				text = {
+					"当一个{C:attention}披萨片{}被出售时，",
+					"这张小丑获得{X:mult,C:white}X#1#{} 倍率",
+					"{C:inactive}(当前 {X:mult,C:white}X#2#{}{C:inactive} 倍率){}",
 				},
 			},
 			j_cry_pot_of_jokes = {
 				name = "小丑之壶",
 				text = {
 					"{C:attention}#1#{}手牌上限,",
-					"每回合增加{C:blue}#2#{} ",
+					"每回合增加{C:blue}#2#{}",
+				},
+				unlock = {
+					"将你的{C:attention}手牌上限{}",
+					"提升至{C:attention}12",
+				},
+			},
+			j_cry_poor_joker = {
+				name = "贫穷小丑",
+				text = {
+					"当一张{C:attention}租赁{}牌扣除金钱时，",
+					"此小丑获得{C:mult}+#1#{}倍率",
+					"{C:inactive}(当前{} {C:mult}+#2#{} {C:inactive}倍率){}",
 				},
 			},
 			j_cry_primus = {
 				name = "素数",
 				text = {
-					"这张小丑获得 {X:dark_edition,C:white} ^#1# {} 倍率",
+					"这张小丑获得 {X:dark_edition,C:white} ^#1# {}倍率",
 					"如果手中打出的所有牌都是",
 					"{C:attention}A{}、{C:attention}2{}、{C:attention}3{}、{C:attention}5{} 或 {C:attention}7{}",
-					"{C:inactive}(当前 {X:dark_edition,C:white} ^#2# {C:inactive} 倍率)",
+					"{C:inactive}(当前 {X:dark_edition,C:white} ^#2# {C:inactive}倍率)",
+				},
+			},
+			j_cry_pumpkin = {
+				name = "南瓜",
+				text = {
+					"如果得分筹码至少达到所需筹码的{C:attention}50%{}，则不会死亡",
+					"被{C:red}摧毁{}时变为{C:attention}雕刻南瓜",
+				},
+			},
+			j_cry_carved_pumpkin = {
+				name = "雕刻南瓜",
+				text = {
+					"接下来的{C:attention}#1#{}个Boss盲注",
+					"其能力将被{C:attention}禁用",
 				},
 			},
 			j_cry_python = {
@@ -1986,9 +2718,14 @@ return {
 			j_cry_quintet = {
 				name = "五重奏",
 				text = {
-					"{X:mult,C:white} X#1# {} 倍率如果出牌",
+					"{X:mult,C:white} X#1# {}倍率如果出牌",
 					"手牌包含",
 					"一个{C:attention}#2#",
+				},
+				unlock = {
+					"赢得一局游戏",
+					"且最终打出的牌型为",
+					"{E:1,C:attention}五条",
 				},
 			},
 			j_cry_redbloon = {
@@ -2000,8 +2737,8 @@ return {
 			j_cry_redeo = {
 				name = "回溯",
 				text = {
-					"当花费{C:money}$#2#{} {C:inactive}($#3#){} 时",
-					"{C:attention}-#1#{} 底注",
+					"当花费{C:money}$#2#{}{C:inactive}($#3#){}时",
+					"{C:attention}-#1#{}底注",
 					"每次使用{C:attention,s:0.8}指数增加{}花费",
 					"{C:money,s:0.8}下次增加：{s:1,c:money}$#4#",
 				},
@@ -2030,6 +2767,19 @@ return {
 				text = {
 					"每次{C:attention}底注{}时随机能力",
 				},
+				unlock = {
+					"{C:green}1 / 20{}的概率",
+					"在{C:attention}游戏结束{}时解锁此卡",
+				},
+			},
+			j_cry_rotten_egg = {
+				name = "臭鸡蛋",
+				text = {
+					"获得时，将所有当前和未来小丑的售价设置为{C:attention}$#1#{}",
+					"所有{C:attention}小丑{}的售价降低{C:attention}$#2#{}",
+					"回合结束时，从出售{C:attention}小丑{}中获得{C:attention}$#3#{} {C:inactive}[#4#]{}后，",
+					"{C:red}自毁{}",
+				},
 			},
 			j_cry_sacrifice = {
 				name = "献祭",
@@ -2047,13 +2797,13 @@ return {
 				text = {
 					"当{C:attention}#2#{} {C:inactive}[#1#]{} 张{C:attention}增强牌{}计分后",
 					"卖掉此牌",
-					"以获得一张{C:cry_epic}史诗{} {C:attention}小丑{}",
+					"以获得一张{C:cry_epic}史诗{}{C:attention}小丑{}",
 				},
 			},
 			j_cry_savvy = {
 				name = "精明小丑",
 				text = {
-					"如果出的牌中包含 {C:attention}#2#",
+					"如果打出的牌中包含{C:attention}#2#",
 					"{C:chips}+#1#{} 筹码",
 				},
 			},
@@ -2062,7 +2812,7 @@ return {
 				text = {
 					"当打出手牌时，",
 					"会有{C:green}#1#/#2#{}几率生成一张",
-					"{C:dark_edition}欢愉 {C:green}罕见{}小丑",
+					"{C:dark_edition}欢愉{C:green}罕见{}小丑",
 				},
 			},
 			j_cry_seal_the_deal = {
@@ -2075,22 +2825,22 @@ return {
 			j_cry_shrewd = {
 				name = "敏锐小丑",
 				text = {
-					"如果出的牌中包含 {C:attention}#2#",
+					"如果打出的牌中包含{C:attention}#2#",
 					"{C:chips}+#1#{} 筹码",
 				},
 			},
 			j_cry_silly = {
 				name = "傻傻小丑",
 				text = {
-					"如果出的牌中包含 {C:attention}#2#",
+					"如果打出的牌中包含{C:attention}#2#",
 					"{C:red}+#1#{} 倍率",
 				},
 			},
 			j_cry_smallestm = {
 				name = "超小M",
 				text = {
-					"打出 {C:attention}#1#{} 时",
-					"创造一个 {C:cry_jolly}M 标签{}",
+					"打出{C:attention}#1#{}时",
+					"创造一个{C:cry_jolly}M 标签{}",
 					"{C:inactive,s:0.8}好吧，基本上我很小",
 				},
 			},
@@ -2102,6 +2852,48 @@ return {
 					"{C:attention}+#1#{} 手牌上限",
 					"{C:attention}+#1#{} 消耗牌槽位",
 					"{C:attention}+#1#{} 商店栏位",
+					"{C:attention}+#1#{} 优惠券槽位",
+				},
+				unlock = {
+					"仅使用{C:attention}高牌{}",
+					"赢得一局游戏",
+				},
+			},
+			j_cry_soccer_balanced = {
+				name = "合众为一",
+				text = {
+					"{C:attention}+#1#{} 补充包槽位",
+					"{C:attention}+#1#{} 手牌上限",
+					"{C:attention}+#1#{} 消耗牌槽位",
+					"{C:attention}+#1#{} 商店栏位",
+					"{C:attention}+#1#{} 优惠券槽位",
+				},
+				unlock = {
+					"仅使用{C:attention}高牌{}",
+					"赢得一局游戏",
+				},
+			},
+			j_cry_sock_and_sock = {
+				name = "袜子配袜子",
+				text = {
+					"重新触发所有打出的",
+					"{C:attention}抽象{}牌{C:attention}#1#{}次",
+				},
+			},
+			j_cry_brokenhome = {
+				name = "破碎家园",
+				text = {
+					"{X:mult,C:white}X#1#{}倍率",
+					"回合结束时",
+					"有{C:green}#2#/#3#{}的概率",
+					"摧毁此牌",
+				},
+			},
+			j_cry_yarnball = {
+				name = "毛线球",
+				text = {
+					"将最高等级{C:attention}猫咪标签{}的等级",
+					"添加到所有{C:green}列出的概率{}中",
 				},
 			},
 			j_cry_spaceglobe = {
@@ -2131,7 +2923,7 @@ return {
 			j_cry_spy = {
 				name = "间谍",
 				text = {
-					"{X:mult,C:white} X#2# {} 倍率, {C:dark_edition}+1{C:attention} 小丑槽{} ",
+					"{X:mult,C:white} X#2# {}倍率, {C:dark_edition}+1{C:attention}小丑槽{} ",
 					"{C:inactive} #1# 是间谍!",
 				},
 			},
@@ -2142,12 +2934,19 @@ return {
 					"每张提供{X:mult,C:white}X#1#{} 倍率",
 				},
 			},
+			j_cry_starfruit = {
+				name = "杨桃",
+				text = {
+					"{X:dark_edition,C:white}^#1#{} 倍率，",
+					"商店中每{C:attention}重掷{}一次，失去{X:dark_edition,C:white}^#2#{} 倍率",
+				},
+			},
 			j_cry_stella_mortis = {
 				name = "星逝",
 				text = {
 					"{C:attention}商店{}结束时",
 					"摧毁一张随机{C:planet}星球{}牌",
-					"并在获得 {X:dark_edition,C:white} ^#1# {} 倍率",
+					"并在获得 {X:dark_edition,C:white} ^#1# {}倍率",
 					"{C:inactive}(当前 {X:dark_edition,C:white} ^#2# {C:inactive} 倍率)",
 				},
 			},
@@ -2156,13 +2955,18 @@ return {
 				text = {
 					"如果打出的手牌包含",
 					"一个 {C:attention}#2#",
-					"{X:mult,C:white} X#1# {} 倍率",
+					"{X:mult,C:white} X#1# {}倍率",
+				},
+				unlock = {
+					"赢得一局游戏",
+					"且最终打出的牌型为",
+					"{E:1,C:attention}碉堡",
 				},
 			},
 			j_cry_subtle = {
 				name = "微妙小丑",
 				text = {
-					"如果出的牌中包含 {C:attention}#2#",
+					"如果打出的牌中包含{C:attention}#2#",
 					"{C:chips}+#1#{} 筹码",
 				},
 			},
@@ -2170,6 +2974,13 @@ return {
 				name = "Supercell",
 				text = {
 					"{C:chips}+#1#{} 筹码, {C:mult}+#1#{} 倍率,",
+					"{X:chips,C:white}X#2#{} 筹码, {X:mult,C:white}X#2#{} 倍率",
+					"在回合结束时获得 {C:money}$#3#{}",
+				},
+			},
+			j_cry_supercell_balanced = {
+				name = "Supercell",
+				text = {
 					"{X:chips,C:white}X#2#{} 筹码, {X:mult,C:white}X#2#{} 倍率",
 					"在回合结束时获得 {C:money}$#3#{}",
 				},
@@ -2185,15 +2996,20 @@ return {
 			j_cry_swarm = {
 				name = "虫群",
 				text = {
-					"{X:mult,C:white} X#1# {} 倍率如果出牌",
+					"{X:mult,C:white} X#1# {}倍率如果出牌",
 					"手牌包含",
 					"一个{C:attention}#2#",
+				},
+				unlock = {
+					"赢得一局游戏",
+					"且最终打出的牌型为",
+					"{E:1,C:attention}同花五条",
 				},
 			},
 			j_cry_sync_catalyst = {
 				name = "同步催化剂",
 				text = {
-					"平衡 {C:chips}筹码{} 和 {C:mult}倍率{}",
+					"平衡{C:chips}筹码{}和{C:mult}倍率{}",
 					"{C:inactive,s:0.8}嘿！我之前见过这个！（等离子牌组效果）",
 				},
 			},
@@ -2201,15 +3017,15 @@ return {
 				name = "逃税",
 				text = {
 					"回合结束后",
-					"每有一个 {C:attention}租用小丑{}",
-					"获得 {C:attention}$#1#{}",
+					"每有一个{C:attention}租用小丑{}",
+					"获得{C:attention}$#1#{}",
 				},
 			},
 			j_cry_tenebris = {
 				name = "暗黑",
 				text = {
-					"{C:dark_edition}+#1#{C:attention} 小丑{}槽",
-					"在回合结束时获得 {C:money}$#2#{}",
+					"{C:dark_edition}+#1#{C:attention}小丑{}槽",
+					"在回合结束时获得{C:money}$#2#{}",
 				},
 			},
 			j_cry_translucent = {
@@ -2224,23 +3040,59 @@ return {
 				name = "诡谲小丑",
 				text = {
 					"如果打出的手牌包含",
-					"一个 {C:attention}#2#",
+					"一个{C:attention}#2#",
 					"{C:chips}+#1#{} 筹码",
+				},
+			},
+			j_cry_nebulous = {
+				name = "朦胧小丑",
+				text = {
+					"如果打出的手牌是{C:attention}#2#{}",
+					"获得{C:chips}+#1#{}筹码",
+				},
+			},
+			j_cry_words_cant_even = {
+				name = "言语甚至无法描述的小丑",
+				text = {
+					"如果打出的手牌包含",
+					"一个{C:attention}#2#{}",
+					"获得{X:mult,C:white}X#1#{}倍率",
+				},
+			},
+			j_cry_many_lost_minds = {
+				name = "无数人因试图理解他而发狂的小丑",
+				text = {
+					"如果打出的手牌包含",
+					"一个{C:attention}#2#{}",
+					"获得{C:chips}+#1#{}筹码",
+				},
+			},
+			j_cry_annihalation = {
+				name = "彻底摧毁 Balatro 神圣的终极小丑",
+				text = {
+					"如果打出的手牌包含",
+					"一个{C:attention}#2#{}",
+					"获得{X:dark_edition,C:white}^#1#{}倍率",
+				},
+				unlock = {
+					"赢得一局游戏",
+					"且最终打出的牌型为",
+					"{E:1,C:attention}#1#",
 				},
 			},
 			j_cry_trick_or_treat = {
 				name = "不给糖就捣蛋",
 				text = {
 					" {C:attention}出售时{}:",
-					"{C:green}#1# / #2#{} 几率创建 {C:attention}2{}个 {C:cry_candy}糖果",
-					"否则 创建一个 {X:cry_cursed,C:white}诅咒小丑{} ",
+					"{C:green}#1# / #2#{} 几率创建 {C:attention}2{}个{C:cry_candy}糖果",
+					"否则创建一个{X:cry_cursed,C:white}诅咒小丑{} ",
 					"{C:inactive}(可以溢出)",
 				},
 			},
 			j_cry_tricksy = {
 				name = "诡诈小丑",
 				text = {
-					"如果出的牌中包含 {C:attention}#2#",
+					"如果打出的牌中包含{C:attention}#2#",
 					"{C:chips}+#1#{} 筹码",
 				},
 			},
@@ -2249,7 +3101,7 @@ return {
 				text = {
 					"计分牌中刚好有",
 					" {C:attention}3 张 3 {}时",
-					"提供{X:mult,C:white} X#1# {} 倍率",
+					"提供{X:mult,C:white} X#1# {}倍率",
 				},
 			},
 			j_cry_tropical_smoothie = {
@@ -2262,23 +3114,28 @@ return {
 			j_cry_unity = {
 				name = "团结",
 				text = {
-					"{X:mult,C:white} X#1# {} 倍率如果出牌",
+					"{X:mult,C:white} X#1# {}倍率如果出牌",
 					"手牌包含",
 					"一个{C:attention}#2#",
+				},
+				unlock = {
+					"赢得一局游戏",
+					"且最终打出的牌型为",
+					"{E:1,C:attention}同花葫芦",
 				},
 			},
 			j_cry_universe = {
 				name = "宇宙",
 				text = {
-					"每张{C:dark_edition}星界{} ",
-					"提供 {X:dark_edition,C:white}^#1#{} 倍率",
+					"每张{C:dark_edition}星界{}",
+					"提供{X:dark_edition,C:white}^#1#{} 倍率",
 				},
 			},
 			j_cry_universum = {
 				name = "寰宇",
 				text = {
 					"{C:attention}牌型{}升级时获得",
-					"{X:red,C:white} X#1# {} 倍率和 {X:blue,C:white} X#1# {} 筹码",
+					"{X:red,C:white} X#1# {}倍率和{X:blue,C:white} X#1# {}筹码",
 				},
 			},
 			j_cry_unjust_dagger = {
@@ -2296,7 +3153,7 @@ return {
 				text = {
 					"当任何概率",
 					"{C:green}成功{}触发时，",
-					"这张小丑获得{X:red,C:white}X 倍率{}",
+					"这张小丑获得{X:red,C:white}X倍率{}",
 					"等于其列出的{C:attention}概率",
 					"{C:inactive}(当前 {X:mult,C:white} X#1# {C:inactive} 倍率)",
 				},
@@ -2304,17 +3161,17 @@ return {
 			j_cry_virgo = {
 				name = "室女座",
 				text = {
-					"如果 {C:attention}果出牌牌型{} 包含一个 {C:attention}#2#{}",
-					"该小丑增加 {C:money}$#1#{} {C:attention}售价{}",
+					"如果{C:attention}果出牌牌型{}包含一个{C:attention}#2#{}",
+					"该小丑增加{C:money}$#1#{}{C:attention}售价{}",
 					"出售这张牌时",
-					"每 {C:money}$4{} 的 {C:attention}出售价值{}{C:dark_edition}创造一张多彩{} {C:attention}开心小丑{}，",
+					"每{C:money}$4{}的{C:attention}出售价值{}{C:dark_edition}创造一张多彩{}{C:attention}开心小丑{}",
 					" {C:inactive}(至少 1){}",
 				},
 			},
 			j_cry_wacky = {
 				name = "搞怪小丑",
 				text = {
-					"如果出的牌中包含 {C:attention}#2#",
+					"如果打出的牌中包含{C:attention}#2#",
 					"{C:red}+#1#{} 倍率",
 				},
 			},
@@ -2322,7 +3179,7 @@ return {
 				name = "瓦路易吉",
 				text = {
 					"所有小丑提供",
-					"{X:mult,C:white} X#1# {} 倍率",
+					"{X:mult,C:white} X#1# {}倍率",
 				},
 			},
 			j_cry_wario = {
@@ -2336,7 +3193,7 @@ return {
 				name = "微波那契数列",
 				text = {
 					"这个小丑获得",
-					"{C:mult}+#2#{} 倍率，当打出的每张",
+					"{C:mult}+#2#{}倍率，当打出的每张",
 					"{C:attention}A{}, {C:attention}2{}, {C:attention}3{}, {C:attention}5{}, 或 {C:attention}8{}",
 					"计分时",
 					"{C:inactive}(当前 {C:mult}+#1#{C:inactive} 倍率)",
@@ -2346,31 +3203,38 @@ return {
 				name = "2D",
 				text = {
 					"每张计分的2",
-					"重新触发 {C:attention:}#1#{} 次",
-					"{C:inactive,s:0.8}我们身处游戏中吗 {}",
+					"重新触发{C:attention:}#1#{}次",
+					"{C:inactive,s:0.8}我们身处游戏中吗{}",
 				},
 			},
 			j_cry_wheelhope = {
 				name = "希望之轮",
 				text = {
 					"当{C:attention}命运之轮{}效果失败",
-					"这张牌获得{X:mult,C:white} X#1# {} 倍率",
+					"这张牌获得{X:mult,C:white} X#1# {}倍率",
 					"{C:inactive}(当前{X:mult,C:white} X#2# {C:inactive} 倍率)",
 				},
 			},
 			j_cry_whip = {
 				name = "长鞭",
 				text = {
-					"这张小丑获得 {X:mult,C:white} X#1# {} 倍率",
-					"如果 {C:attention}出牌手牌{} 包含",
-					"不同花色的{C:attention}2{} 和 {C:attention}7{}",
+					"这张小丑获得{X:mult,C:white} X#1# {}倍率",
+					"如果{C:attention}出牌手牌{}包含",
+					"不同花色的{C:attention}2{}和{C:attention}7{}",
 					"{C:inactive}(当前 {X:mult,C:white} X#2# {C:inactive} 倍率)",
+				},
+			},
+			j_cry_wonka_bar = {
+				name = "Wonka 巧克力",
+				text = {
+					"出售此卡以永久获得",
+					"{C:attention}+#1#{}卡牌选择上限",
 				},
 			},
 			j_cry_wrapped = {
 				name = "包裹糖果",
 				text = {
-					"{C:attention}#1#{} 回合后",
+					"{C:attention}#1#{}回合后",
 					"创建一个随机的{C:attention}食物小丑{}",
 					"{C:red,E:2}自毁{}",
 				},
@@ -2379,8 +3243,13 @@ return {
 				name = "我操！？",
 				text = {
 					"如果打出的手牌包含",
-					"一个 {C:attention}#2#",
-					"{X:mult,C:white} X#1# {} 倍率",
+					"一个{C:attention}#2#",
+					"{X:mult,C:white} X#1# {}倍率",
+				},
+				unlock = {
+					"赢得一局游戏",
+					"且最终打出的牌型为",
+					"{E:1,C:attention}#1#",
 				},
 			},
 			j_cry_zooble = {
@@ -2394,6 +3263,7 @@ return {
 			},
 		},
 		Other = {
+	
 			banana = {
 				name = "香蕉",
 				text = {
@@ -2407,12 +3277,20 @@ return {
 					"{C:inactive,s:0.8}我讨厌这张牌- SDM_0, 2024{}",
 				},
 			},
+			cry_absolute = {
+				name = "绝对",
+				text = {
+					"不能出售",
+					"或被摧毁",
+					"{C:attention}不可移除{}",
+				},
+			},
 			cry_azure_seal = {
 				name = "蔚蓝蜡封",
 				text = {
 					"打出附带该蜡封的牌时",
 					"{C:red}摧毁{}这张牌",
-					"之后创造 {C:attention}#1#{} 张 {C:dark_edition}负片{}{C:planet}对应牌型的星球牌{}",
+					"之后创造{C:attention}#1#{}张{C:dark_edition}负片{}{C:planet}对应牌型的星球牌{}",
 				},
 			},
 			cry_banana_booster = {
@@ -2452,21 +3330,43 @@ return {
 			cry_flickering = {
 				name = "闪烁",
 				text = {
-					"{C:attention}#1#{} 次触发后摧毁",
+					"{C:attention}#1#{}次触发后摧毁",
 					"{C:inactive}(剩余{C:attention}#2#{C:inactive} 次)",
 				},
 			},
 			cry_flickering_desc = {
 				name = "闪烁",
 				text = {
-					"{C:attention}#1#{} 次触发后摧毁",
+					"{C:attention}#1#{}次触发后摧毁",
+				},
+			},
+			cry_function_sticker = {
+				name = "函数://",
+				text = {
+					"使用后按顺序依次创建",
+					"{C:cry_code}#1#{}、{C:cry_code}#2#{}和{C:cry_code}#3#{}",
+				},
+			},
+			cry_function_sticker_desc = {
+				name = "函数://",
+				text = {
+					"创建一张",
+					"带有{C:cry_code}函数://{}贴纸的消耗牌",
+					"{C:inactive}当前：#1#、#2#和#3#{}",
+				},
+			},
+			cry_global_sticker = {
+				name = "全局",
+				text = {
+					"尽可能在其他牌之前",
+					"{C:cry_code}抽到此卡{}",
 				},
 			},
 			cry_green_seal = {
 				name = "秩绿蜡封",
 				text = {
 					"仅当被打出且不计分时",
-					"创造一张 {C:cry_code}代码{} 卡牌",
+					"创造一张{C:cry_code}代码{}卡牌",
 					"{C:inactive}(必须有空间)",
 				},
 			},
@@ -2481,6 +3381,12 @@ return {
 				name = "M",
 				text = {
 					"{C:attention,s:0.7}更新{s:0.7} 默认情况下被禁用 ({C:attention,s:0.7}HTTPS模块{s:0.7})",
+				},
+			},
+			cry_multiuse = {
+				name = "多次使用",
+				text = {
+					"{C:inactive}多次使用: ({C:inactive}剩余{C:cry_code}#1#{C:inactive}次)",
 				},
 			},
 			cry_perishable_booster = {
@@ -2499,7 +3405,7 @@ return {
 			cry_perishable_voucher = {
 				name = "易腐优惠券",
 				text = {
-					"{C:attention}#1#{} 回合后被削弱",
+					"{C:attention}#1#{}回合后被削弱",
 					"{C:inactive}({C:attention}#2#{C:inactive} 剩余)",
 				},
 			},
@@ -2527,9 +3433,9 @@ return {
 			cry_possessed = {
 				name = "作祟",
 				text = {
-					"{C:attention}禁用{} 此牌效果",
+					"{C:attention}禁用{}此牌效果",
 					"如果可能的话{C:attention}反转{}此牌的效果",
-					"随着 {C:attention}幽灵{}的摧毁而摧毁",
+					"随着{C:attention}幽灵{}的摧毁而摧毁",
 				},
 			},
 			cry_rental_booster = {
@@ -2542,13 +3448,13 @@ return {
 			cry_rental_consumeable = {
 				name = "租赁消耗牌",
 				text = {
-					"回合结束时和使用时失去 {C:money}$#1#{}",
+					"回合结束时和使用时失去{C:money}$#1#{}",
 				},
 			},
 			cry_rental_voucher = {
 				name = "租赁优惠券",
 				text = {
-					"回合结束时失去 {C:money}$#1#{}",
+					"回合结束时失去{C:money}$#1#{}",
 				},
 			},
 			cry_rigged = {
@@ -2558,19 +3464,44 @@ return {
 					"都{C:cry_code}必定触发",
 				},
 			},
+			disabled = {
+				name = "Disabled",
+				text = {
+					"不再在本局游戏中出现",
+				},
+			},
+			disabled_card_dependency = {
+				name = "Disabled",
+				text = {
+					"需要{C:attention}#1#",
+				},
+			},
+			disabled_mod_dependency = {
+				name = "Disabled",
+				text = {
+					"需要mod: {C:attention}#1#",
+				},
+			},
+			disabled_mod_conflict = {
+				name = "Disabled",
+				text = {
+					"与以下mod冲突:",
+					"{C:attention}#1#",
+				},
+			},
 			ev_cry_choco0 = {
 				name = "",
 				text = {
 					"激活事件后",
-					"{C:cry_ascendant,E:1}事件{} 的具体信息将会出现",
+					"{C:cry_ascendant,E:1}事件{}的具体信息将会出现",
 				},
 			},
 			ev_cry_choco1 = {
 				name = "1: 恶灵附身",
 				text = {
-					"{C:attention}小丑牌{} 和打出的牌有",
+					"{C:attention}小丑牌{}和打出的牌有",
 					"{C:green}1 / 3{} 几率获得闪烁",
-					"创造一张 {C:attention}幽灵",
+					"创造一张{C:attention}幽灵",
 					"{C:inactive,s:0.7}你被幽灵附身了",
 					"{C:inactive,s:0.7}意识时而清醒，时而模糊",
 				},
@@ -2578,9 +3509,9 @@ return {
 			ev_cry_choco10 = {
 				name = "10: 珍贵古董",
 				text = {
-					"一张售价{C:money}$50{}的 {C:legendary}传奇{} {C:attention}小丑{} ",
-					"出现在商店 {C:attention}优惠券{}槽位",
-					"只有作为商店 {C:attention}最后一件物品{} 时才能购买",
+					"一张售价{C:money}$50{}的{C:legendary}传奇{}{C:attention}小丑{} ",
+					"出现在商店{C:attention}优惠券{}槽位",
+					"只有作为商店{C:attention}最后一件物品{}时才能购买",
 					"{C:inactive,s:0.7}你已经引起了遗物之灵的注意，",
 					"{C:inactive,s:0.7}但想要平息它，可没那么简单",
 				},
@@ -2588,9 +3519,9 @@ return {
 			ev_cry_choco2 = {
 				name = "2: 鬼屋",
 				text = {
-					"不能跳过 {C:attention}盲注{}",
-					"商店中只能 {C:attention}重掷{} 一次",
-					"{C:attention}优惠券{} 售价翻倍",
+					"不能跳过{C:attention}盲注{}",
+					"商店中只能{C:attention}重掷{}一次",
+					"{C:attention}优惠券{}售价翻倍",
 					"{C:inactive,s:0.7}幽灵们已经占领这里！",
 					"{C:inactive,s:0.7}千万别碰任何东西，快点逃出去！",
 				},
@@ -2598,9 +3529,9 @@ return {
 			ev_cry_choco3 = {
 				name = "3: 女巫药剂",
 				text = {
-					"创造3个 {C:attention}魔药",
+					"创造3个{C:attention}魔药",
 					"在{C:attention}小盲注{}结束前使用其中之一",
-					"否则 {C:attention}所有的{} 减益效果都会在这个{C:attention}底注{}生效",
+					"否则{C:attention}所有的{}减益效果都会在这个{C:attention}底注{}生效",
 					"{C:inactive,s:0.7}你被女巫绑架了！",
 					"{C:inactive,s:0.7}她盯着你，递上三瓶药剂",
 					"{C:inactive,s:0.7}选一个吧，不然她可要替你做决定了。",
@@ -2609,9 +3540,9 @@ return {
 			ev_cry_choco4 = {
 				name = "4: 月之深渊",
 				text = {
-					"打出的牌有 {C:green}1 / 4{} 几率",
-					"变为随机的 {C:club}梅花{} 人头牌",
-					"将 {C:attention}倍率{} 除以打出人头牌的数量",
+					"打出的牌有{C:green}1 / 4{} 几率",
+					"变为随机的{C:club}梅花{}人头牌",
+					"将{C:attention}倍率{}除以打出人头牌的数量",
 					"{C:inactive,s:0.7}即便是心地善良、",
 					"{C:inactive,s:0.7}夜晚虔诚祈祷之人……",
 				},
@@ -2619,11 +3550,11 @@ return {
 			ev_cry_choco5 = {
 				name = "5: 吸血鬼",
 				text = {
-					"移除所有打出的牌的 {C:attention}增强{} ",
+					"移除所有打出的牌的{C:attention}增强{} ",
 					"并有{C:green}1 / 3{} 几率摧毁",
-					"{C:heart}红桃{} 和 {C:diamond}方块{} 卡牌",
+					"{C:heart}红桃{}和{C:diamond}方块{}卡牌",
 					"{C:inactive,s:0.7}夜深人静时，你必须更加谨慎，",
-					"{C:inactive,s:0.7,E:1}因为它们在阴影中{C:inactive,s:0.7} 伺机满足自己的饥渴……",
+					"{C:inactive,s:0.7,E:1}因为它们在阴影中{C:inactive,s:0.7}伺机满足自己的饥渴……",
 				},
 			},
 			ev_cry_choco6 = {
@@ -2637,9 +3568,9 @@ return {
 			ev_cry_choco7 = {
 				name = "7: 节日气氛",
 				text = {
-					"创建三个 {C:attention}不给糖就捣蛋{} 和一个 {C:attention}糖果篮子",
-					"每回合商店有一个 {C:attention}不给糖就捣蛋{}",
-					"获得{C:cry_candy}糖果{} 时，得到{C:money}$3{}",
+					"创建三个{C:attention}不给糖就捣蛋{}和一个{C:attention}糖果篮子",
+					"每回合商店有一个{C:attention}不给糖就捣蛋{}",
+					"获得{C:cry_candy}糖果{}时，得到{C:money}$3{}",
 					"{C:inactive,s:0.7}整个社区都为恐怖的盛会装饰一新,",
 					"{C:inactive,s:0.7}快来享受这节日气氛吧！",
 				},
@@ -2647,8 +3578,8 @@ return {
 			ev_cry_choco8 = {
 				name = "8: 糖果雨",
 				text = {
-					"击败 {C:attention}盲注{} 后, 每剩余一次出牌获得 1 个{C:cry_candy}糖果{}",
-					"当获得一个{C:cry_candy}糖果{}后，获得一个 {C:attention}食物小丑{}",
+					"击败{C:attention}盲注{}后, 每剩余一次出牌获得 1 个{C:cry_candy}糖果{}",
+					"当获得一个{C:cry_candy}糖果{}后，获得一个{C:attention}食物小丑{}",
 					"{C:inactive,s:0.7}糖果从天而降！",
 					"{C:inactive,s:0.7,E:1}快点，抓住你能抓到的所有糖果！",
 				},
@@ -2656,8 +3587,8 @@ return {
 			ev_cry_choco9 = {
 				name = "9: 鬼魅财富",
 				text = {
-					"获得 {C:money}$20",
-					"所有赚到的 {C:money}钱{} 都变为 {C:attention}双倍",
+					"获得{C:money}$20",
+					"所有赚到的{C:money}钱{}都变为{C:attention}双倍",
 					"{C:inactive,s:0.7}你已故亲戚的幽灵在午夜时分来访！",
 					"{C:inactive,s:0.7}他们默默地将一袋钱放在你的手中，",
 					"{C:inactive,s:0.7}温暖一笑，随即化为虚影消散在空气中~",
@@ -2680,61 +3611,70 @@ return {
 					"{s:0.8}玉米片，幽灵可乐，汉堡，披萨",
 				},
 			},
+			p_cry_baneful_1 = {
+				name = "诅咒小丑包",
+				text = {
+					"从最多{C:attention}#2#张{X:cry_cursed,C:white}诅咒{}小丑中",
+					"选择{C:attention}#1#张{}",
+					"{C:attention}跳过{}将{C:red}移除{}",
+					"最右侧拥有的小丑",
+				},
+			},
 			p_cry_code_jumbo_1 = {
 				name = "巨型代码包",
 				text = {
-					"选择 {C:attention}#1#{} 张最多",
-					"{C:attention}#2#{C:cry_code} 代码{} 卡牌",
+					"选择{C:attention}#1#{}张最多",
+					"{C:attention}#2#{C:cry_code}代码{}卡牌",
 				},
 			},
 			p_cry_code_mega_1 = {
 				name = "超级代码包",
 				text = {
-					"选择 {C:attention}#1#{} 张最多",
-					"{C:attention}#2#{C:cry_code} 代码{} 卡牌",
+					"选择{C:attention}#1#{}张最多",
+					"{C:attention}#2#{C:cry_code}代码{}卡牌",
 				},
 			},
 			p_cry_code_normal_1 = {
 				name = "代码补充包",
 				text = {
-					"选择 {C:attention}#1#{} 张最多",
-					"{C:attention}#2#{C:cry_code} 代码{} 卡牌",
+					"选择{C:attention}#1#{}张最多",
+					"{C:attention}#2#{C:cry_code}代码{}卡牌",
 				},
 			},
 			p_cry_code_normal_2 = {
 				name = "代码补充包",
 				text = {
-					"选择 {C:attention}#1#{} 张最多",
-					"{C:attention}#2#{C:cry_code} 代码{} 卡牌",
+					"选择{C:attention}#1#{}张最多",
+					"{C:attention}#2#{C:cry_code}代码{}卡牌",
 				},
 			},
 			p_cry_empowered = {
 				name = "究极幻灵包",
 				text = {
-					"选择 {C:attention}#1#{} 张，最多",
-					"{C:attention}#2#{C:spectral} 幻灵{}牌",
+					"选择{C:attention}#1#{}张，最多",
+					"{C:attention}#2#{C:spectral}幻灵{}牌",
 					"{s:0.8,C:inactive}(由强化标签生成)",
 				},
 			},
 			p_cry_meme_1 = {
 				name = "玩梗包1",
 				text = {
-					"选择 {C:attention}#1#{} 张，最多",
-					"可达 {C:attention}#2# 张玩梗的小丑{}",
+					"选择{C:attention}#1#{}张，最多",
+					"可达{C:attention}#2#张玩梗的小丑{}",
 				},
 			},
 			p_cry_meme_three = {
 				name = "玩梗包3",
 				text = {
-					"选择 {C:attention}#1#{} 张，最多",
-					"可达 {C:attention}#2# 张玩梗的小丑{}",
+					"选择{C:attention}#1#{}张，最多",
+					"可达{C:attention}#2#张玩梗的小丑{}",
 				},
 			},
 			p_cry_meme_two = {
 				name = "玩梗包2",
 				text = {
-					"选择 {C:attention}#1#{} 张，最多",
-					"可达 {C:attention}#2# 张玩梗的小丑{}",
+					"选择{C:attention}#1#{}张，最多",
+					"可达{C:attention}#2#张玩梗的小丑{}",
 				},
 			},
 			undiscovered_code = {
@@ -2758,7 +3698,7 @@ return {
 			c_cry_Kaikki = {
 				name = "Kaikki",
 				text = {
-					"({V:1}等级.#4#{})({V:2}等级.#5#{})({V:3}等级.#6#{})",
+					"({V:1}等级#4#{})({V:2}等级#5#{})({V:3}等级#6#{})",
 					"升级",
 					"{C:attention}#1#{},",
 					"{C:attention}#2#{},",
@@ -2769,7 +3709,7 @@ return {
 			c_cry_Klubi = {
 				name = "Klubi",
 				text = {
-					"({V:1}等级.#4#{})({V:2}等级.#5#{})({V:3}等级.#6#{})",
+					"({V:1}等级#4#{})({V:2}等级#5#{})({V:3}等级#6#{})",
 					"升级",
 					"{C:attention}#1#{},",
 					"{C:attention}#2#{},",
@@ -2780,7 +3720,7 @@ return {
 			c_cry_Lapio = {
 				name = "Lapio",
 				text = {
-					"({V:1}等级.#4#{})({V:2}等级.#5#{})({V:3}等级.#6#{})",
+					"({V:1}等级#4#{})({V:2}等级#5#{})({V:3}等级#6#{})",
 					"升级",
 					"{C:attention}#1#{},",
 					"{C:attention}#2#{},",
@@ -2791,7 +3731,7 @@ return {
 			c_cry_Sydan = {
 				name = "Sydan",
 				text = {
-					"({V:1}等级.#4#{})({V:2}等级.#5#{})({V:3}等级.#6#{})",
+					"({V:1}等级#4#{})({V:2}等级#5#{})({V:3}等级#6#{})",
 					"升级",
 					"{C:attention}#1#{},",
 					"{C:attention}#2#{},",
@@ -2799,10 +3739,10 @@ return {
 					"（芬兰语Heart）",
 				},
 			},
-			c_cry_Timantti = {
-				name = "Timantti",
+			c_cry_Timantii = {
+				name = "Timantii",
 				text = {
-					"({V:1}等级.#4#{})({V:2}等级.#5#{})({V:3}等级.#6#{})",
+					"({V:1}等级#4#{})({V:2}等级#5#{})({V:3}等级#6#{})",
 					"升级",
 					"{C:attention}#1#{},",
 					"{C:attention}#2#{},",
@@ -2813,7 +3753,7 @@ return {
 			c_cry_asteroidbelt = {
 				name = "小行星带",
 				text = {
-					"{S:0.8}({S:0.8,V:1}等级.#1#{S:0.8}){} 升级",
+					"{S:0.8}({S:0.8,V:1}等级#1#{S:0.8}){} 升级",
 					"{C:attention}#2#",
 					"{C:mult}+#3#{} 倍率和",
 					"{C:chips}+#4#{} 筹码",
@@ -2822,7 +3762,7 @@ return {
 			c_cry_marsmoons = {
 				name = "火卫一和土卫二",
 				text = {
-					"{S:0.8}({S:0.8,V:1}等级.#1#{S:0.8}){} 升级",
+					"{S:0.8}({S:0.8,V:1}等级#1#{S:0.8}){} 升级",
 					"{C:attention}#2#",
 					"{C:mult}+#3#{} 倍率和",
 					"{C:chips}+#4#{} 筹码",
@@ -2837,6 +3777,15 @@ return {
 					"{C:inactive}(当前{C:attention} #1#{C:inactive}){}",
 				},
 			},
+			c_cry_nibiru = {
+				name = "尼比鲁",
+				text = {
+					"{S:0.8}({S:0.8,V:1}等级#1#{S:0.8}){} 升级",
+					"{C:attention}#2#",
+					"{C:mult}+#3#{} 倍率和",
+					"{C:chips}+#4#{} 筹码",
+				},
+			},
 			c_cry_planetlua = {
 				name = "星球.lua",
 				text = {
@@ -2848,7 +3797,7 @@ return {
 			c_cry_universe = {
 				name = "TM的整个宇宙！",
 				text = {
-					"{S:0.8}({S:0.8,V:1}等级.#1#{S:0.8}){} 升级",
+					"{S:0.8}({S:0.8,V:1}等级#1#{S:0.8}){} 升级",
 					"{C:attention}#2#",
 					"{C:mult}+#3#{} 倍率和",
 					"{C:chips}+#4#{} 筹码",
@@ -2857,16 +3806,27 @@ return {
 			c_cry_void = {
 				name = "虚空",
 				text = {
-					"{S:0.8}({S:0.8,V:1}等级.#1#{S:0.8}){} 升级",
+					"{S:0.8}({S:0.8,V:1}等级#1#{S:0.8}){} 升级",
 					"{C:attention}#2#",
 					"{C:mult}+#3#{} 倍率和",
 					"{C:chips}+#4#{} 筹码",
 				},
 			},
+			c_cry_voxel = {
+				name = "Voxel",
+				text = {
+					"({V:1}等级#4#{})({V:2}等级#5#{})({V:3}等级#6#{})",
+					"升级",
+					"{C:attention}#1#{},",
+					"{C:attention}#2#{},",
+					"以及{C:attention}#3#{}",
+					"{C:inactive,S:0.8}(译者注:升级的为使用{C:cry_code}://声明{}创建的牌型)",
+				},
+			},
 			c_cry_sunplanet = {
 				name = "太阳",
 				text = {
-					"{S:0.8}({S:0.8,V:1}等级.#1#{S:0.8}){}",
+					"{S:0.8}({S:0.8,V:1}等级#1#{S:0.8}){}",
 					"使{C:attention}晋升{}牌型的指数",
 					"增加{X:gold,C:white}#2#{}",
 					"{C:inactive}(目前指数 {X:gold,C:white}X(#3#^晋升数){C:inactive})",
@@ -2874,10 +3834,32 @@ return {
 			},
 		},
 		Sleeve = {
+			sleeve_cry_beige_sleeve = {
+				name = "四重牌套",
+				text = {
+					"{C:attention}普通{}小丑具有",
+					"{C:attention}四倍{}的效果",
+				},
+			},
+			sleeve_cry_beige_sleeve_alt = {
+				name = "四重牌套",
+				text = {
+					"{C:attention}罕见{}小丑具有",
+					"{C:attention}四倍{}的效果",
+				},
+			},
+			sleeve_cry_beta_sleeve = {
+				name = "怀旧牌套",
+				text = {
+					"{C:attention}小丑牌槽{}和{C:attention}消耗牌槽{}",
+					"{C:attention}合并",
+					"boss底注被替换为它们的怀旧版本",
+				},
+			},
 			sleeve_cry_bountiful_sleeve = {
 				name = "丰饶牌套",
 				text = {
-					"每次{C:attention}出牌{} 或 {C:attention}弃牌{}后",
+					"每次{C:attention}出牌{}或{C:attention}弃牌{}后",
 					"固定抽五张牌",
 				},
 			},
@@ -2885,32 +3867,32 @@ return {
 				name = "CCD 牌套",
 				text = {
 					"每张卡牌也是",
-					"一张 {C:attention}随机{} 消耗牌",
+					"一张{C:attention}随机{}消耗牌",
 				},
 			},
 			sleeve_cry_conveyor_sleeve = {
 				name = "传送带牌套",
 				text = {
-					"{C:attention}不能{} 移动小丑卡",
+					"{C:attention}不能{}移动小丑卡",
 					"回合开始时，",
-					"{C:attention}复制{} 最右边的小丑卡",
-					"并且 {C:attention}销毁{} 最左边的小丑卡",
+					"{C:attention}复制{}最右边的小丑卡",
+					"并且{C:attention}销毁{}最左边的小丑卡",
 				},
 			},
 			sleeve_cry_critical_sleeve = {
 				name = "暴击牌套",
 				text = {
 					"每打出一手牌后，",
-					"{C:green}四分之一{} 的几率获得 {X:dark_edition,C:white} ^2 {} 倍",
-					"{C:green}八分之一{} 的几率获得 {X:dark_edition,C:white} ^0.5 {} 倍",
+					"{C:green}1/4{}几率获得{X:dark_edition,C:white} ^2 {}倍率",
+					"{C:green}1/8{}几率获得{X:dark_edition,C:white} ^0.5 {}倍率",
 				},
 			},
 			sleeve_cry_encoded_sleeve = {
 				name = "编码牌套",
 				text = {
-					"开始时获得一张 {C:cry_code,T:j_cry_CodeJoker}代码小丑卡{}",
-					"和一张 {C:cry_code,T:j_cry_copypaste}复制/粘贴卡{}",
-					"商店中只出现 {C:cry_code}代码牌{}",
+					"开始时获得一张{C:cry_code,T:j_cry_curse_sob}代码小丑卡{}",
+					"和一张{C:cry_code,T:j_cry_copypaste}复制/粘贴{}",
+					"商店中只出现{C:cry_code}代码牌{}",
 				},
 			},
 			sleeve_cry_equilibrium_sleeve = {
@@ -2922,17 +3904,26 @@ return {
 					"{C:attention,T:v_overstock_plus}+2 商店栏位",
 				},
 			},
+			sleeve_cry_glowing_sleeve = {
+				name = "发光牌组",
+				text = {
+					"在击败Boss盲注时，",
+					"所有小丑牌的数值乘以{X:dark_edition,C:white}X1.25{}",
+					"{X:cry_jolly,C:white,s:0.8} Jolly#1#Open#1#Winner#1#-#1#wawa#1#person",
+				},
+			},
+
 			sleeve_cry_infinite_sleeve = {
 				name = "无限牌套",
 				text = {
-					"你可以选择 {C:attention}任意数量",
+					"你可以选择{C:attention}任意数量",
 					"的卡牌",
 				},
 			},
 			sleeve_cry_legendary_sleeve = {
 				name = "传奇牌套",
 				text = {
-					"以一张 {C:legendary}传奇{C:legendary} 小丑牌开始",
+					"以一张{C:legendary}传奇{C:legendary}小丑牌开始",
 					"击败Boss盲注后",
 					"{C:green}1 / 5{} 几率创建另外一张",
 					"{C:inactive}(必须有空间){}",
@@ -2942,31 +3933,53 @@ return {
 				name = "错印牌套",
 				text = {
 					"卡牌的数值",
-					"是 {C:attention}随机{} 的",
+					"是{C:attention}随机{}的",
 				},
 			},
 			sleeve_cry_redeemed_sleeve = {
 				name = "赎回牌套",
 				text = {
-					"当购买{C:attention}优惠券{} 时，",
-					"会获得对应 {C:attention}高级{} 版",
+					"当购买{C:attention}优惠券{}时，",
+					"会获得对应{C:attention}高级{}版",
 				},
 			},
 			sleeve_cry_spooky_sleeve = {
 				name = "万圣节牌套",
 				text = {
-					"以一张{C:eternal}永恒{} {C:attention,T:j_cry_chocolate_dice}巧克力骰{}开始",
-					"每次{C:attention}底注{}之后 ",
-					"创建一个{C:cry_candy}糖果{}或 {X:cry_cursed,C:white}诅咒{}",
+					"以一张{C:eternal}永恒{}{C:attention,T:j_cry_chocolate_dice}巧克力骰{}开始",
+					"每个{C:attention}底注{}结束后,",
+					"创建一个{C:cry_candy}糖果{}或{X:cry_cursed,C:white}诅咒{}",
+				},
+			},
+			sleeve_cry_very_fair_sleeve = {
+				name = "超平衡的牌组",
+				text = {
+					"每回合{C:blue}-2{}手牌，{C:red}-2{}弃牌",
+					"{C:attention}优惠券{}不再出现在商店中",
 				},
 			},
 			sleeve_cry_wormhole_sleeve = {
 				name = "虫洞牌套",
 				text = {
-					"开始时获得一张 {C:cry_exotic}域外{C:attention} 小丑卡",
-					"小丑卡 {C:attention}20倍{} 更有可能",
-					"成为 {C:dark_edition}负片{} 卡",
-					"{C:attention}-2{} 小丑卡插槽",
+					"开始时获得一张{C:cry_exotic}域外{C:attention}小丑卡",
+					"小丑牌{C:attention}20倍{}更有可能成为{C:dark_edition}负片{}",
+					"{C:attention}-2{}小丑牌槽位",
+				},
+			},
+			sleeve_cry_antimatter_sleeve = {
+				name = "反物质牌套",
+				text = {
+					"拥有{C:attention}所有{}牌套的",
+					"{C:attention}增益{}和{C:attention}特殊增益{}效果",
+					"{C:red}WIP",
+				},
+			},
+			sleeve_cry_antimatter_sleeve_balanced = {
+				name = "Antimatter Sleeve",
+				text = {
+					"拥有{C:attention}所有{}在{C:gold}金注{}中获胜过的",
+					"牌组的{C:attention}增益{}和{C:attention}特殊增益{}效果",
+					"{C:red}WIP",
 				},
 			},
 		},
@@ -2974,36 +3987,35 @@ return {
 			c_cry_adversary = {
 				name = "敌手",
 				text = {
-					"拥有的{C:red}所有{} {C:attention}小丑牌{} 变为 {C:dark_edition}负片{},",
+					"拥有的{C:red}所有{}{C:attention}小丑牌{}变为{C:dark_edition}负片{},",
 					"本局游戏的小丑牌购买价格{C:red}翻倍{}",
 				},
 			},
 			c_cry_analog = {
 				name = "模拟",
 				text = {
-					"复制 {C:attention}#1#{} 张",
-					"随机 {C:attention}小丑{}",
-					"摧毁所有其他小丑，{C:attention}+#2#{} 底注",
+					"为一个随机{C:attention}小丑{}生成{C:attention}#1#{}张复制",
+					"摧毁所有其他小丑，{C:attention}+#2#{}底注",
 				},
 			},
 			c_cry_chambered = {
 				name = "腔室",
 				text = {
-					"随机复制 {C:attention}#1#{}张 {C:dark_edition}负片{}版本",
+					"随机复制{C:attention}#1#{}张{C:dark_edition}负片{}版本",
 					"的{C:attention}持有{}的消耗牌",
 				},
 			},
 			c_cry_conduit = {
 				name = "渠道",
 				text = {
-					"交换两张所选择的小丑或手牌的 {C:attention}版本{}",
+					"交换两张所选择的小丑或手牌的{C:attention}版本{}",
 				},
 			},
 			c_cry_gateway = {
 				name = "真理之门",
 				text = {
 					"生成一张随机的",
-					"{C:cry_exotic,E:1}域外{C:attention} 小丑{}",
+					"{C:cry_exotic,E:1}域外{C:attention}小丑{}",
 					"摧毁所有其他小丑",
 				},
 			},
@@ -3017,16 +4029,16 @@ return {
 			c_cry_lock = {
 				name = "锁定",
 				text = {
-					"从 {C:red}所有{} 小丑中，",
-					"移除 {C:red}所有{} 贴纸",
-					"然后随机给一张小丑牌增加 {C:purple,E:1}永恒{}贴纸",
+					"从{C:red}所有{}小丑中，",
+					"移除{C:red}所有{}贴纸",
+					"然后随机给一张小丑牌增加{C:purple,E:1}永恒{}贴纸",
 				},
 			},
 			c_cry_pointer = {
 				name = "://指针",
 				text = {
 					"创造一张",
-					"任选 {C:cry_code}卡牌",
+					"任选{C:cry_code}卡牌",
 					"{C:inactive,s:0.8}(域外小丑 #1# 排除)",
 					"（输入对应名字）",
 				},
@@ -3035,85 +4047,91 @@ return {
 				name = "复录",
 				text = {
 					"转换所有手牌",
-					"为一张 {C:attention}随机{}",
+					"为一张{C:attention}随机{}",
 					"手牌",
 				},
 			},
 			c_cry_ritual = {
 				name = "仪典",
 				text = {
-					"增强 {C:attention}#1#{} 张选定的卡牌",
-					"为 {C:dark_edition}负片{}, {C:dark_edition}马赛克{}",
-					"或 {C:dark_edition}星界{} ",
+					"增强{C:attention}#1#{}张选定的卡牌",
+					"为{C:dark_edition}负片{}, {C:dark_edition}马赛克{}",
+					"或{C:dark_edition}星界{}",
 				},
 			},
 			c_cry_source = {
 				name = "源码",
 				text = {
-					"向你手中的",
-					"{C:attention}#1#{} 选定卡牌",
-					"添加一个 {C:cry_code}绿色蜡封{}",
+					"向你手中的{C:attention}#1#{}张选定的牌",
+					"添加{C:cry_code}绿色蜡封{}"
 				},
 			},
 			c_cry_summoning = {
 				name = "召唤",
 				text = {
 					"创造一张随机的",
-					"{C:cry_epic}史诗{} {C:joker}小丑{}，摧毁",
-					"一张随机 {C:joker}小丑{}",
+					"{C:cry_epic}史诗{}{C:joker}小丑{}，摧毁",
+					"一张随机{C:joker}小丑{}",
 				},
 			},
 			c_cry_trade = {
 				name = "交易",
 				text = {
-					"{C:attention}失去{} 一张随机优惠券，",
-					"获得 {C:attention}2{} 张随机优惠券",
+					"{C:attention}失去{}1张随机优惠券，",
+					"获得{C:attention}2{}张随机优惠券",
 				},
 			},
 			c_cry_typhoon = {
 				name = "台风",
 				text = {
-					"向手中 {C:attention}#1#{} 选择的",
-					"牌中添加 {C:cry_azure}蔚蓝蜡封{}",
+					"向你手中的{C:attention}#1#{}张选定的牌",
+					"添加{C:cry_azure}蔚蓝蜡封{}"
 				},
 			},
 			c_cry_meld = {
 				name = "融合",
 				text = {
-					"选择一张 {C:attention}小丑{} 或",
-					"{C:attention}扑克牌{} 将其变成",
-					"{C:dark_edition}双面{} ",
+					"选择一张{C:attention}小丑{}或",
+					"{C:attention}扑克牌{}将其变成",
+					"{C:dark_edition}双面{}",
 				},
 			},
 			c_cry_vacuum = {
 				name = "虚空",
 				text = {
-					"从 {C:red}所有{} 手中的牌，",
-					"移除 {C:red}所有 {C:green}修改{}",
-					"每移除一个 {C:green}修改{}，获得 {C:money}$#1#{}",
+					"从{C:red}所有{}手中的牌，",
+					"移除{C:red}所有{C:green}修改{}",
+					"每移除一个{C:green}修改{}，获得{C:money}$#1#{}",
 					"{C:inactive,s:0.7}(例如: 强化、蜡封、版本)",
 				},
 			},
 			c_cry_white_hole = {
 				name = "白洞",
 				text = {
-					"{C:attention}移除{} 所有手牌等级，",
-					"升级 {C:legendary,E:1}最常用{} 扑克牌型",
+					"升级{C:legendary,E:1}最常用{}扑克牌型{C:attention}4{}级",
+					"{C:attention}移除{}所有其他手牌等级",
+				},
+			},
+			c_cry_white_hole2 = {
+				name = "白洞",
+				text = {
+					"{C:attention}移除{}所有手牌等级，",
+					"升级{C:legendary,E:1}最常用{}扑克牌型",
 					"每移除1级，最常用牌型升{C:attention}3{}级",
 				},
 			},
 		},
 		Stake = {
 			stake_cry_amber = {
-				colour = "Amber",
+				colour = "琥珀",
 				name = "琥珀注",
 				text = {
-					"商店的{C:attention}补充包-1{} ",
+					"商店的{C:attention}补充包-1{}",
 					"{s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_ascendant = {
-				colour = "Ascendant",
+				colour = "飞升",
 				name = "飞升注",
 				text = {
 					"商店栏位{C:attention}-1{}",
@@ -3121,7 +4139,7 @@ return {
 				},
 			},
 			stake_cry_azure = {
-				colour = "Azure",
+				colour = "蔚蓝",
 				name = "蔚蓝注",
 				text = {
 					"所有小丑牌的数值降低",
@@ -3130,59 +4148,58 @@ return {
 				},
 			},
 			stake_cry_blossom = {
-				colour = "Blossom",
+				colour = "花锦",
 				name = "花锦注",
 				text = {
 					"{C:attention}最终{}Boss版盲注可以出现在",
 					"{C:attention}任何{}底注中",
 					"{s:0.8,C:inactive}之前所有赌注也都起效{}",
-					"",
 				},
 			},
 			stake_cry_bronze = {
-				colour = "Bronze",
+				colour = "青铜",
 				name = "青铜注",
 				text = {
-					"优惠券价格增加 {C:attention}50%{}",
+					"优惠券价格增加{C:attention}50%{}",
 					"{s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_brown = {
-				colour = "Brown",
+				colour = "棕色",
 				name = "棕色注",
 				text = {
-					"所有的 {C:attention}贴纸（如永恒，易腐，租赁）{} 互相兼容",
+					"所有的{C:attention}贴纸（如永恒，易腐，租赁）{}互相兼容",
 					"{s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_crimson = {
-				colour = "Crimson",
+				colour = "猩红",
 				name = "猩红注",
 				text = {
-					"优惠券只会在 {C:attention}双数{} 底注 时刷新",
+					"优惠券只会在{C:attention}双数{}底注时刷新",
 					"{s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_cyan = {
-				colour = "Cyan",
+				colour = "靛青",
 				name = "靛青注",
 				text = {
-					"{C:green}罕见的{} 和 {C:red}稀有的{} 小丑牌出现概率",
-					"减少",
+					"{C:green}罕见{}和{C:red}稀有{}小丑牌出现",
+					"概率降低",
 					"{s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_dawn = {
-				colour = "Dawn",
+				colour = "黎明",
 				name = "黎明注",
 				text = {
-					"塔罗牌和幻灵牌的选择目标 {C:attention}减 1{}",
+					"塔罗牌和幻灵牌的选择目标{C:attention}减 1{}",
 					"{s:0.8,C:inactive}(最少 1 张){}",
 					"{s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_diamond = {
-				colour = "Diamond",
+				colour = "钻石",
 				name = "钻石注",
 				text = {
 					"获胜的底注变成{C:attention}10{}",
@@ -3190,7 +4207,7 @@ return {
 				},
 			},
 			stake_cry_ember = {
-				colour = "Ember",
+				colour = "余烬",
 				name = "余烬注",
 				text = {
 					"所有卡牌出售时不再产生金钱",
@@ -3198,65 +4215,65 @@ return {
 				},
 			},
 			stake_cry_emerald = {
-				colour = "Emerald",
+				colour = "翡翠",
 				name = "翡翠注",
 				text = {
-					"卡牌、包和优惠券可以是 {C:attention}面朝下{} 的",
+					"卡牌、包和优惠券可以是{C:attention}面朝下{}的",
 					"{s:0.8,C:inactive}(购买前无法查看)",
 					"{s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_glass = {
-				colour = "Glass",
+				colour = "玻璃",
 				name = "玻璃注",
 				text = {
-					"卡牌在得分时可能会被 {C:attention}摧毁",
+					"卡牌在得分时可能会被{C:attention}摧毁",
 					"{}{s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_gray = {
-				colour = "Gray",
+				colour = "灰色",
 				name = "灰色注",
 				text = {
-					"重新投掷的费用每次增加 {C:attention}$2{}",
+					"重新投掷的费用每次增加{C:attention}$2{}",
 					"{s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_horizon = {
-				colour = "Horizon",
+				colour = "地平线",
 				name = "地平线注",
 				text = {
 					"选择盲注时，增加一张",
-					"{C:attention}随机卡牌{} 到牌堆",
+					"{C:attention}随机卡牌{}到牌堆",
 					" {s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_jade = {
-				colour = "Jade",
+				colour = "碧玉",
 				name = "碧玉注",
 				text = {
-					"抽取手牌时有概率是 {C:attention}面朝下{} 的",
+					"抽取手牌时有概率是{C:attention}面朝下{}的",
 					"{s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_pink = {
-				colour = "Pink",
+				colour = "粉红",
 				name = "粉红注",
 				text = {
-					" {C:attention}底注 {}提升时，过关需求分数再次增速",
+					"{C:attention}底注{}提升时，过关需求分数再次增速",
 					"{s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_platinum = {
-				colour = "Platinum",
+				colour = "铂金",
 				name = "铂金注",
 				text = {
-					"小盲注 {C:attention}不会出现{}",
+					"小盲注{C:attention}不会出现{}",
 					"{s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_quartz = {
-				colour = "Quartz",
+				colour = "石英",
 				name = "石英注",
 				text = {
 					"商店有可能出现{C:attention}固定{}小丑牌",
@@ -3265,25 +4282,25 @@ return {
 				},
 			},
 			stake_cry_ruby = {
-				colour = "Ruby",
+				colour = "红玉",
 				name = "红玉注",
 				text = {
-					"{C:attention}大{} 盲注有可能变为",
-					"{C:attention}Boss{} 盲注",
+					"{C:attention}大{}盲注有可能变为",
+					"{C:attention}Boss{}盲注",
 					"{s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_sapphire = {
-				colour = "Sapphire",
+				colour = "蓝晶",
 				name = "蓝晶注",
 				text = {
-					"在 底注 结束时，失去当前总资金的 {C:attention}25%{} ",
-					"{s:0.8,C:inactive}(最高失去至 $10)",
+					"在底注结束时，失去当前总资金的{C:attention}25%{}",
+					"{s:0.8,C:inactive}(最高失去至$10)",
 					"{s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_twilight = {
-				colour = "Twilight",
+				colour = "暮光",
 				name = "暮光注",
 				text = {
 					"商店有可能出现{C:attention}香蕉{}小丑牌",
@@ -3292,15 +4309,15 @@ return {
 				},
 			},
 			stake_cry_verdant = {
-				colour = "Verdant",
+				colour = "翠绿",
 				name = "翠绿注",
 				text = {
-					"所需分数会随每个 {C:attention}底注加速增加",
+					"所需分数会随每个{C:attention}底注加速增加",
 					"{s:0.8,C:inactive}之前所有赌注也都起效{}",
 				},
 			},
 			stake_cry_yellow = {
-				colour = "Yellow",
+				colour = "灿黄",
 				name = "灿黄注",
 				text = {
 					"{C:attention}永恒，易腐，租赁等贴纸{}",
@@ -3314,7 +4331,7 @@ return {
 				name = "星界标签",
 				text = {
 					"下一张在商店里的小丑",
-					"增加 {C:dark_edition}星界版本{}并且免费",
+					"增加{C:dark_edition}星界版本{}并且免费",
 				},
 			},
 			tag_cry_banana = {
@@ -3333,7 +4350,7 @@ return {
 			tag_cry_bettertop_up = {
 				name = "进阶充值标签",
 				text = {
-					"创造 {C:attention}#1#张{C:green}罕见{}小丑",
+					"创造{C:attention}#1#张{C:green}罕见{}小丑",
 					"{C:inactive}（必须有空间）{}",
 				},
 			},
@@ -3347,16 +4364,16 @@ return {
 			tag_cry_booster = {
 				name = "增强包标签",
 				text = {
-					"下一个 {C:cry_code}增强包{} 有",
-					"{C:attention}双倍{} 卡牌数量",
-					"{C:attention}双倍{} 选择次数",
+					"下一个{C:cry_code}增强包{}有",
+					"{C:attention}双倍{}卡牌数量",
+					"{C:attention}双倍{}选择次数",
 				},
 			},
 			tag_cry_bundle = {
 				name = "组合标签",
 				text = {
-					"创造一个 {C:attention}标准标签{}，{C:tarot}吊饰标签{}，",
-					"{C:attention}小丑标签{}，和 {C:planet}流星标签",
+					"创造一个{C:attention}标准标签{}，{C:tarot}吊饰标签{}，",
+					"{C:attention}小丑标签{}，和{C:planet}流星标签",
 				},
 			},
 			tag_cry_cat = {
@@ -3373,17 +4390,24 @@ return {
 					"{C:cry_code}代码包",
 				},
 			},
+			tag_cry_clone = {
+				name = "克隆标签",
+				text = {
+					"商店物品价格为原来的{C:attention}X#1#{}倍，",
+					"获得下一张购买卡牌的{C:attention}复制{}",
+				},
+			},
 			tag_cry_double_m = {
 				name = "M标签",
 				text = {
-					"商店增加一张 {C:legendary}M系列小丑{}",
+					"商店增加一张{C:legendary}M系列小丑{}",
 				},
 			},
 			tag_cry_empowered = {
 				name = "强化标签",
 				text = {
-					"给予一个 {C:spectral}究极幻灵{} 包",
-					"包括 {C:legendary,E:1}灵魂{} 和 {C:cry_exotic,E:1}传送门{}",
+					"给予一个{C:spectral}究极幻灵{}包",
+					"包括{C:legendary,E:1}灵魂{}和{C:cry_exotic,E:1}真理之门{}",
 				},
 			},
 			tag_cry_epic = {
@@ -3397,14 +4421,14 @@ return {
 				name = "赌徒标签",
 				text = {
 					"{C:green}#1# / #2#{} 的几率",
-					"创造一个 {C:cry_exotic,E:1}强化{} 标签",
+					"创造一个{C:cry_exotic,E:1}强化{}标签",
 				},
 			},
 			tag_cry_glass = {
 				name = "琉璃标签",
 				text = {
 					"下一张在商店里的小丑",
-					"增加 {C:dark_edition}灰质琉璃{}版本并且免费",
+					"增加{C:dark_edition}灰质琉璃{}版本并且免费",
 				},
 			},
 			tag_cry_glitched = {
@@ -3418,7 +4442,7 @@ return {
 				name = "鎏金标签",
 				text = {
 					"下一张在商店里的小丑",
-					"增加 {C:dark_edition}鎏金版本{}并且免费",
+					"增加{C:dark_edition}鎏金版本{}并且免费",
 				},
 			},
 			tag_cry_gourmand = {
@@ -3435,18 +4459,25 @@ return {
 					"的{C:cry_ascendant}玩梗{}包",
 				},
 			},
+			tag_cry_lens = {
+				name = "透镜标签",
+				text = {
+					"将{C:dark_edition}负片{}效果",
+					"添加至{C:attention}#1#{}个随机消耗牌上",
+				},
+			},
 			tag_cry_m = {
 				name = "欢愉~标签",
 				text = {
 					"下一张在商店里的小丑",
-					"增加 {C:dark_edition}欢愉{}版本并且免费",
+					"增加{C:dark_edition}欢愉{}版本并且免费",
 				},
 			},
 			tag_cry_memory = {
 				name = "记忆标签",
 				text = {
-					"创造 {C:attention}#1#{} 份",
-					"本局游戏上一次使用的 {C:attention}标签{}",
+					"创造{C:attention}#1#{}份",
+					"本局游戏上一次使用的{C:attention}标签{}",
 					"{s:0.8,C:inactive}复制类标签除外",
 					"{s:0.8,C:inactive}当前: {s:0.8,C:attention}#2#",
 				},
@@ -3455,29 +4486,36 @@ return {
 				name = "马赛克标签",
 				text = {
 					"下一张在商店里的小丑",
-					"增加 {C:dark_edition}马赛克版本{}并且免费",
+					"增加{C:dark_edition}马赛克版本{}并且免费",
 				},
 			},
 			tag_cry_oversat = {
 				name = "过曝标签",
 				text = {
 					"下一张在商店里的小丑",
-					"增加 {C:dark_edition}过曝版本{}并且免费",
+					"增加{C:dark_edition}过曝版本{}并且免费",
+				},
+			},
+			tag_cry_palette_cleanser = {
+				name = "清洁标签",
+				text = {
+					"从{C:attention}随机{}一个小丑或扑克牌上",
+					"移除一个{C:attention}随机{}贴纸",
 				},
 			},
 			tag_cry_quadruple = {
 				name = "四方标签",
 				text = {
-					"给予 {C:attention}#1#{} 份",
-					"下一个选择的 {C:attention}标签",
+					"给予{C:attention}#1#{}份",
+					"下一个选择的{C:attention}标签",
 					"{s:0.8,C:inactive}复制类标签除外",
 				},
 			},
 			tag_cry_quintuple = {
 				name = "五重标签",
 				text = {
-					"给予 {C:attention}#1#{} 份",
-					"下一个选择的 {C:attention}标签",
+					"给予{C:attention}#1#{}份",
+					"下一个选择的{C:attention}标签",
 					"{s:0.8,C:inactive}复制类标签除外",
 				},
 			},
@@ -3485,14 +4523,14 @@ return {
 				name = "重制标签",
 				text = {
 					"商店有一张",
-					"{C:dark_edition}#1# {C:cry_code}#2#",
+					"{C:dark_edition}#1#{C:cry_code}#2#",
 				},
 			},
 			tag_cry_schematic = {
 				name = "原理图标签",
 				text = {
 					"下个商店有一张",
-					"{C:attention}头脑风暴{} ",
+					"{C:attention}头脑风暴{}",
 				},
 			},
 			tag_cry_scope = {
@@ -3505,8 +4543,8 @@ return {
 			tag_cry_triple = {
 				name = "三连标签",
 				text = {
-					"给予 {C:attention}#1#{} 份",
-					"下一个选择的 {C:attention}标签",
+					"给予{C:attention}#1#{}份",
+					"下一个选择的{C:attention}标签",
 					"{s:0.8,C:inactive}复制类标签除外",
 				},
 			},
@@ -3515,31 +4553,38 @@ return {
 			c_cry_automaton = {
 				name = "机械人",
 				text = {
-					"创造 {C:attention}#1#",
-					"随机 {C:cry_code}代码{} 卡",
+					"创造{C:attention}#1#",
+					"随机{C:cry_code}代码{}卡",
 					"{C:inactive}(必须有空间)",
 				},
 			},
 			c_cry_eclipse = {
 				name = "日食",
 				text = {
-					"增强 {C:attention}#1#{} 张选定的卡牌",
-					"为 {C:attention}回响卡",
+					"增强{C:attention}#1#{}张选定的卡牌",
+					"为{C:attention}回响卡",
+				},
+			},
+			c_cry_instability = {
+				name = "不稳定性",
+				text = {
+					"将{C:attention}#1#{}张选定卡牌",
+					"增强为{C:attention}抽象牌",
 				},
 			},
 			c_cry_theblessing = {
 				name = "祝福",
 				text = {
-					"创造 {C:attention}1{}",
-					"随机 {C:attention}消耗牌{}",
+					"创造{C:attention}1{}",
+					"随机{C:attention}消耗牌{}",
 					"{C:inactive}(必须有空间){}",
 				},
 			},
 			c_cry_seraph = {
 				name = "六翼天使",
 				text = {
-					"增强 {C:attention}#1#{} 张选定的手牌",
-					"为 {C:attention}明亮牌",
+					"增强{C:attention}#1#{}张选定的手牌",
+					"为{C:attention}明亮牌",
 				},
 			},
 		},
@@ -3547,7 +4592,7 @@ return {
 			c_cry_potion = {
 				name = "魔药",
 				text = {
-					"使用后获取一种未知的 ",
+					"使用后获取一种未知的",
 					"{C:attention}魔力{}",
 					"{C:inactive,s:0.7}从巧克力骰子中获取",
 				},
@@ -3557,13 +4602,21 @@ return {
 			v_cry_asteroglyph = {
 				name = "星象文字",
 				text = {
-					"设置底注为 {C:attention}#1#{}",
+					"设置底注为{C:attention}#1#{}",
+				},
+				unlock = {
+					"到达底注",
+					"{C:attention}36",
 				},
 			},
 			v_cry_blankcanvas = {
 				name = "空白画布",
 				text = {
-					"{C:attention}+#1#{} 手牌上限",
+					"{C:attention}+#1#{}手牌上限",
+				},
+				unlock = {
+					"将你的{C:attention}手牌上限",
+					"降至{C:attention}0",
 				},
 			},
 			v_cry_clone_machine = {
@@ -3571,13 +4624,13 @@ return {
 				text = {
 					"双倍标签变成",
 					"{C:attention}五重标签{}，并且",
-					" {C:attention}4X{} 常见",
+					" {C:attention}4X{}常见",
 				},
 			},
 			v_cry_command_prompt = {
 				name = "命令提示符",
 				text = {
-					"{C:cry_code}代码{} 牌可以",
+					"{C:cry_code}代码{}牌可以",
 					"出现在 {C:attention}商店{}",
 				},
 			},
@@ -3586,34 +4639,43 @@ return {
 				text = {
 					"双倍标签变成",
 					"{C:attention}三连标签{}，并且",
-					"是 {C:attention}2X{} 常见",
+					"是 {C:attention}2X{}常见",
 				},
 			},
 			v_cry_curate = {
 				name = "策展",
 				text = {
 					"所有牌出现时均",
-					"带有 {C:dark_edition}版本{}",
+					"带有{C:dark_edition}版本{}",
+				},
+				unlock = {
+					"发现所有",
+					"{C:attention}版本",
 				},
 			},
 			v_cry_dexterity = {
 				name = "灵巧",
 				text = {
 					"永久",
-					"每回合获得 {C:blue}+#1#{} 手牌",
+					"每回合获得{C:blue}+#1#{}出牌",
+				},
+				unlock = {
+					"累计打出",
+					"{C:attention}5000张{}",
+					"{C:attention}扑克牌{}",
 				},
 			},
 			v_cry_double_down = {
 				name = "双倍下注",
 				text = {
 					"每轮之后，",
-					" {C:dark_edition}双面{} 牌背面的所有数值 {X:dark_edition,C:white} X1.5 {}",
+					" {C:dark_edition}双面{}牌背面的所有数值{X:dark_edition,C:white} X1.5 {}",
 				},
 			},
 			v_cry_double_slit = {
 				name = "成对裂隙",
 				text = {
-					"{C:attention}融合{} 可以",
+					"{C:attention}融合{}可以",
 					"出现在商店和",
 					"秘术包中",
 				},
@@ -3621,20 +4683,24 @@ return {
 			v_cry_double_vision = {
 				name = "重影",
 				text = {
-					"{C:dark_edition}双面{} 牌出现",
-					"{C:attention}4X{} 更频繁",
+					"{C:dark_edition}双面{}牌出现",
+					"{C:attention}4X{}更频繁",
 				},
 			},
 			v_cry_fabric = {
 				name = "宇宙结构",
 				text = {
-					"{C:dark_edition}+#1#{} 小丑槽",
+					"{C:dark_edition}+#1#{}小丑槽",
+				},
+				unlock = {
+					"累计兑换{C:dark_edition}反物质{}优惠券",
+					"{C:attention}10次{}",
 				},
 			},
 			v_cry_grapplinghook = {
 				name = "抓钩",
 				text = {
-					"{C:attention}+#1#{} 牌",
+					"{C:attention}+#1#{}牌",
 					"选择限制",
 					"{C:inactive,s:0.7}你可以用它做很多事情，比你想象的要多得多。{}",
 				},
@@ -3642,7 +4708,7 @@ return {
 			v_cry_hyperspacetether = {
 				name = "超时空钩锁",
 				text = {
-					"{C:attention}+#1#{} 牌",
+					"{C:attention}+#1#{}牌",
 					"选择限制",
 					"{C:inactive,s:0.7}注意：未来会有额外的{}",
 					"{C:inactive,s:0.7}功能{}",
@@ -3654,29 +4720,47 @@ return {
 					"商店中的所有牌和包",
 					"费用为 {C:attention}$1{}",
 				},
+				unlock = {
+					"在一局中",
+					"兑换{C:attention}25个{}",
+					"{C:attention}优惠券",
+				},
 			},
 			v_cry_moneybean = {
 				name = "金钱魔豆",
 				text = {
 					"提高每轮获得的",
-					"利息上限至 {C:money}$#1#{}",
+					"利息上限至{C:money}$#1#{}",
+				},
+				unlock = {
+					"在{C:attention}一整局中{}",
+					"达到{C:attention}利息收益{}上限",
 				},
 			},
 			v_cry_overstock_multi = {
 				name = "多重库存",
 				text = {
-					"{C:attention}+#1#{} 卡槽和",
-					"{C:attention}+#1#{} 补充包槽",
+					"{C:attention}+#1#{}卡槽和",
+					"{C:attention}+#1#{}补充包槽",
 					"在商店中可用",
+				},
+				unlock = {
+					"在一局中",
+					"在商店花费{C:attention}1000$",
 				},
 			},
 			v_cry_pacclimator = {
 				name = "星球适应器",
 				text = {
-					"{C:planet}星球{} 牌出现的概率",
-					"{C:attention}X#1#{} ",
+					"{C:planet}星球{}牌出现的概率",
+					"{C:attention}X#1#{}",
 					"购买此优惠券后本赛局所有",
 					"{C:planet}星球{}牌都{C:green}免费{}",
+				},
+				unlock = {
+					"在商店中",
+					"累计购买{C:attention}100张{}",
+					"{C:planet}星球{}牌",
 				},
 			},
 			v_cry_pairamount_plus = {
@@ -3689,35 +4773,40 @@ return {
 			v_cry_pairing = {
 				name = "配对",
 				text = {
-					"{C:attention}重新触发{} 所有 M 小丑",
-					"如果出牌是 {C:attention}一对",
+					"{C:attention}重新触发{}所有 M 小丑",
+					"如果出牌是{C:attention}对子",
 				},
 			},
 			v_cry_quantum_computing = {
 				name = "量子计算",
 				text = {
-					"{C:cry_code}代码{} 牌生成时概率",
-					"带有 {C:dark_edition}负片{} 版本",
+					"{C:cry_code}代码{}牌生成时概率",
+					"带有{C:dark_edition}负片{}版本",
 				},
 			},
 			v_cry_repair_man = {
 				name = "修理工",
 				text = {
-					"{C:attention}重新触发{} 所有 M 小丑",
-					"如果出牌包含 {C:attention}一对",
+					"{C:attention}重新触发{}所有 M 小丑",
+					"如果出牌包含{C:attention}一对",
 				},
 			},
 			v_cry_rerollexchange = {
 				name = "重掷交换",
 				text = {
 					"所有重掷",
-					"费用 {C:attention}$2{}",
+					"费用{C:attention}$2{}",
+				},
+				unlock = {
+					"在一局中",
+					"{C:attention}重掷{}商店",
+					"共计{C:attention}250次{}",
 				},
 			},
 			v_cry_satellite_uplink = {
 				name = "卫星串联",
 				text = {
-					"{C:cry_code}代码{} 牌可能",
+					"{C:cry_code}代码{}牌可能",
 					"出现在任何",
 					"{C:attention}天体包{}中",
 				},
@@ -3725,8 +4814,8 @@ return {
 			v_cry_scope = {
 				name = "银河望远镜",
 				text = {
-					"为出牌创造 {C:planet}星球",
-					"{C:attention}牌型{}",
+					"为出牌{C:attention}牌型{}",
+					"创造对应{C:planet}星球牌{}",
 					"{C:inactive}(必须有空间){}",
 				},
 			},
@@ -3734,16 +4823,21 @@ return {
 				name = "粘粘手",
 				text = {
 					"选择限制",
-					"{C:attention}+#1#{} 牌",
+					"{C:attention}+#1#{}牌",
 				},
 			},
 			v_cry_tacclimator = {
 				name = "塔罗适应器",
 				text = {
-					"{C:tarot}塔罗{} 牌出现的概率",
-					"{C:attention}X#1#{} ",
+					"{C:tarot}塔罗{}牌出现的概率",
+					"{C:attention}X#1#{}",
 					"购买此优惠券后本赛局所有",
 					"{C:tarot}塔罗{}牌都{C:green}免费{}",
+				},
+				unlock = {
+					"在商店中",
+					"累计购买{C:attention}100张{}",
+					"{C:tarot}塔罗{}牌",
 				},
 			},
 			v_cry_tag_printer = {
@@ -3751,14 +4845,19 @@ return {
 				text = {
 					"双倍标签变成",
 					"{C:attention}四方标签{}，并且",
-					" {C:attention}3X{} 常见",
+					" {C:attention}3X{}常见",
 				},
 			},
 			v_cry_threers = {
 				name = "读，写，算",
 				text = {
 					"永久",
-					"每回合获得 {C:red}+#1#{} 弃牌",
+					"每回合获得{C:red}+#1#{}弃牌",
+				},
+				unlock = {
+					"累计弃掉",
+					"{C:attention}5000张{}",
+					"{C:attention}扑克牌{}",
 				},
 			},
 		},
@@ -3778,7 +4877,7 @@ return {
 			ach_cry_jokes_on_you = "在底注 1上触发笑料boss的效果并赢得比赛",
 			ach_cry_niw_uoy = "达到底注 -8",
 			ach_cry_now_the_fun_begins = "获得画布",
-			ach_cry_patience_virtue = "在打出第一手牌之前等待薰衣草环 2分钟并击败盲注",
+			ach_cry_patience_virtue = "在打出第一手牌之前等待薰衣草环2分钟并击败盲注",
 			ach_cry_perfectly_balanced = "使用超平衡牌组击败飞升注",
 			ach_cry_pull_request = "让 ://提交 生成它摧毁的相同小丑",
 			ach_cry_traffic_jam = "击败所有高峰时段挑战",
@@ -3826,9 +4925,13 @@ return {
 			b_flip = "翻转",
 			b_merge = "融合",
 			b_pull = "拉取",
+			b_reset_gameset_modest = "重设游戏集设置(Modest)",
+			b_reset_gameset_mainline = "重设游戏集设置(Mainline)",
+			b_reset_gameset_madness = "重设游戏集设置(Madness)",
 			b_unique_cards = "独特牌",
 			cry_active = "激活",
 			cry_again_q = "再来？",
+			cry_circus_generic = "{V:#1#}#2#{}每个小丑给予{X:mult,C:white} X#3# {}倍率",
 			cry_code_apply = "应用",
 			cry_code_apply_previous = "应用之前的",
 			cry_code_cancel = "取消",
@@ -3836,7 +4939,10 @@ return {
 			cry_code_create_previous = "创建之前的",
 			cry_code_enh = "输入增强",
 			cry_code_enter_card = "输入一张牌",
+			cry_code_enter_hand = "输入扑克牌型",
+			cry_code_empty = "[声明手牌]",
 			cry_code_execute = "执行",
+			cry_code_exit = "离开",
 			cry_code_exploit = "利用",
 			cry_code_exploit_previous = "利用之前的",
 			cry_code_hand = "输入扑克手牌",
@@ -3876,6 +4982,14 @@ return {
 			cry_feat_tags = "标签",
 			["cry_feat_timer mechanics"] = "计时器机制",
 			cry_feat_vouchers = "优惠券",
+			cry_gameset_explanation = {
+				"选择游戏集配置选项以应用于此卡。"
+			},
+			cry_gameset_disabled = "已禁用",
+			cry_gameset_exp = "实验性内容",
+			cry_gameset_exp_modest = "实验性内容(Modest)",
+			cry_gameset_exp_mainline = "实验性内容(Mainline)",
+			cry_gameset_exp_madness = "实验性内容(Madness)",
 			cry_gaming = "游戏中",
 			cry_gaming_ex = "开赌!",
 			cry_good_luck_ex = "祝你好运!",
@@ -3911,6 +5025,12 @@ return {
 			cry_sobbing = "救救我...",
 			cry_sus_ex = "骗子!",
 			cry_unredeemed = "Unredeemed...",
+			cry_view_set_contents = "查看集合中的项目",
+			cry_code_antevoucher = "接下来的Boss盲注和优惠券",
+			cry_code_nextjokers = "下一个商店的小丑",
+			cry_code_nextcards = "接下来抽到的牌",
+			cry_code_with_suits = "包括花色",
+			cry_code_without_suits = "忽略花色",
 			k_code = "代码",
 			k_cry_candy = "糖果",
 			k_cry_cursed = "诅咒",
@@ -3954,24 +5074,94 @@ return {
 			k_cry_exotic = "域外",
 			unique = "独特",
 		},
+		tutorial = {
+			cry_intro_1 = {
+				"你好，我是{C:attention}约瑟夫·J·小丑{}！",
+				"欢迎来到{C:cry_exotic,E:1}Cryptid{}！",
+			},
+			cry_intro_2 = {
+				"看起来你从未在这个存档中",
+				"玩过{C:cry_exotic,E:1}Cryptid{}。",
+				"让我来告诉你怎么玩！",
+			},
+			cry_intro_3 = {
+				"*长出双手*",
+			},
+			cry_intro_4 = {
+				"用几句话总结这个模组很难，",
+				"但我能说的是，你即将经历一段{C:cry_exotic,E:1}疯狂{}的旅程！",
+				"这可不是你熟悉的{C:attention}小丑扑克{}...",
+			},
+			cry_intro_5 = {
+				"你可能从这些{C:cry_ascendant}游戏集{}中看出来了，我喜欢字母{C:attention}M{}。",
+				"选择一个游戏集，我来为你解释...",
+				"{s:0.8}注意：游戏集平衡仍在大力开发中。",
+				"{s:0.8}预计会频繁更新！",
+			},
+			cry_modest_1 = {
+				"想体验接近原版的玩法？",
+				"那么{C:cry_ascendant}Modest{}游戏集适合你！",
+			},
+			cry_modest_2 = {
+				"不过，还是要小心隐藏在",
+				"Cryptid中的各种机制！你永远不知道",
+				"下一轮会遇到什么...",
+			},
+			cry_mainline_1 = {
+				"想{E:1,C:attention}打破{}游戏？好消息，",
+				"不用太离谱就能做到！",
+			},
+			cry_mainline_2 = {
+				"这里的内容仍然很疯狂，但你能有机会",
+				"体验{C:cry_ascendant}成长{}系统。",
+				"只是别太放松...",
+			},
+			cry_mainline_3 = {
+				"因为你会变得更强，但我也设计了一些",
+				"{E:1,C:dark_edition}Boss{}，可能会让你后悔选择这个{C:cry_ascendant}游戏集{}...",
+			},
+			cry_madness_1 = {
+				"想彻底{C:red,E:1}毁灭{}你的硬盘？",
+				"太有趣了！{C:cry_ascendant}Madness{}游戏集的口号是：",
+				"'平衡？{E:1,C:red}那是什么鬼东西！{}'",
+			},
+			cry_madness_2 = {
+				"我花了数周无眠的、喝着{C:green}Mountain Dew{}的夜晚，",
+				"确保这个游戏集{C:cry_ascendant}绝对平衡{}，只为你！",
+			},
+			cry_madness_3 = {
+				"你会解锁所有内容，这样就能释放",
+				"Cryptid的{C:red,E:1}全部力量{}！",
+				"只是小心别让游戏{C:attention,E:1}崩溃{}，",
+				"因为这可能在你失败前就发生...",
+			},
+		},
 		poker_hand_descriptions = {
-			cry_Bulwark = {
+			["cry_Bulwark"] = {
 				"5 张无等级，无花色的牌",
 			},
-			cry_Clusterfuck = {
+			["cry_Clusterfuck"] = {
 				"至少 8 张不包含",
 				"对子、同花或顺子的牌",
 			},
-			cry_UltPair = {
+			["cry_UltPair"] = {
 				"两个两对，共两种花色",
 				"每对两对是一种花色",
 				"他们之间共有两种花色",
 			},
-			cry_WholeDeck = {
+			["cry_WholeDeck"] = {
 				"在一次出牌中，包含",
 				"52张牌的牌组中的每一张牌",
 				"你疯了?",
 			},
+			["cry_None"] = { "出牌为 0 张牌" },
+
+			["cry_Declare0"] = { "始终算作顺子" },
+			["cry_Declare1"] = { "始终算作同花" },
+			["cry_Declare2"] = { "始终算作葫芦" },
+			["cry_Declare0_suitless"] = { "始终算作顺子", "手牌不需要特定花色" },
+			["cry_Declare1_suitless"] = { "始终算作同花", "手牌不需要特定花色" },
+			["cry_Declare2_suitless"] = { "始终算作葫芦", "手牌不需要特定花色" },
 		},
 		poker_hands = {
 			cry_Bulwark = "碉堡",
@@ -3982,113 +5172,113 @@ return {
 		rnj_loc_txts = {
 			actions = {
 				add_dollars = {
-					"获得 {C:money}$#2#{}",
+					"获得{C:money}$#2#{}",
 				},
 				make_joker = {
-					"创造 {C:attention}#2# 小丑{}牌",
+					"创造{C:attention}#2#小丑{}牌",
 				},
 				make_planet = {
-					"创造 {C:attention}#2#{C:planet} 星球{} 牌",
+					"创造{C:attention}#2#{C:planet}星球{}牌",
 				},
 				make_spectral = {
-					"创造 {C:attention}#2#{C:spectral} 幻灵{} 牌",
+					"创造{C:attention}#2#{C:spectral}幻灵{}牌",
 				},
 				make_tarot = {
-					"创造 {C:attention}#2#{C:tarot} 塔罗{} 牌",
+					"创造{C:attention}#2#{C:tarot}塔罗{}牌",
 				},
 			},
 			conds = {
 				big = {
-					"如果 {C:attention}盲注{} 是 {C:attention}大 {C:attention}盲注{}",
+					"如果{C:attention}盲注{}是{C:attention}大{C:attention}盲注{}",
 				},
 				boss = {
-					"如果 {C:attention}盲注{} 是 {C:attention}Boss {C:attention}盲注{}",
+					"如果{C:attention}盲注{}是{C:attention}Boss{C:attention}盲注{}",
 				},
 				buy_common = {
-					"如果是 {C:blue}普通{} {C:attention}小丑{}",
+					"如果是{C:blue}普通{}{C:attention}小丑{}",
 				},
 				buy_uncommon = {
-					"如果是 {C:green}罕见{} {C:attention}小丑{}",
+					"如果是{C:green}罕见{}{C:attention}小丑{}",
 				},
 				common = {
-					"如果是 {C:blue}普通{} {C:attention}小丑{}",
+					"如果是{C:blue}普通{}{C:attention}小丑{}",
 				},
 				discards_left = {
-					"如果回合结束时剩余 {C:red}#3#{} 次丢弃",
+					"如果回合结束时剩余{C:red}#3#{}次弃牌",
 				},
 				face = {
-					"如果卡牌是 {C:attention}面{} 卡",
+					"如果卡牌是{C:attention}人头牌{}",
 				},
 				first = {
-					"如果是 {C:attention}第一次出牌{}",
+					"如果是{C:attention}第一次出牌{}",
 				},
 				first_discard = {
-					"如果是 {C:attention}第一次 {C:attention}丢弃{}",
+					"如果是{C:attention}第一次{C:attention}弃牌{}",
 				},
 				hands_left = {
-					"如果回合结束时剩余 {C:blue}#3#{} 手牌",
+					"如果回合结束时剩余{C:blue}#3#{}手牌",
 				},
 				joker = {
-					"如果卡牌是 {C:attention}小丑{}",
+					"如果卡牌是{C:attention}小丑{}",
 				},
 				last = {
-					"如果是 {C:attention}最后一次{} 出牌",
+					"如果是{C:attention}最后一次{}出牌",
 				},
 				last_discard = {
-					"如果是 {C:attention}最后一次 {C:attention}丢弃{}",
+					"如果是{C:attention}最后一次{C:attention}弃牌{}",
 				},
 				non_boss = {
-					"如果 {C:attention}盲注{} 是 {C:attention}非Boss {C:attention}盲注{}",
+					"如果{C:attention}盲注{}是{C:attention}非Boss{C:attention}盲注{}",
 				},
 				odds = {
-					"以 {C:green}#4# {C:green}中 {C:green}#3#{} 的几率",
+					"以{C:green}#4# / #3#{}的概率",
 				},
 				or_less = {
-					"如果手牌包含 {C:attention}#3#{} 或更少卡牌",
+					"如果手牌包含{C:attention}#3#{}张或更少卡牌",
 				},
 				or_more = {
-					"如果手牌包含 {C:attention}#3#{} 或更多卡牌",
+					"如果手牌包含{C:attention}#3#{}张或更多卡牌",
 				},
 				planet = {
-					"如果卡牌是 {C:planet}星球{} 卡",
+					"如果卡牌是{C:planet}星球牌{}",
 				},
 				poker_hand = {
-					"如果手牌是 {C:attention}#3#{}",
+					"如果手牌是{C:attention}#3#{}",
 				},
 				rank = {
-					"如果卡牌的等级是 {C:attention}#3#{}",
+					"如果卡牌的等级是{C:attention}#3#{}",
 				},
 				rare = {
-					"如果是 {C:red}稀有{} {C:attention}小丑{}",
+					"如果是{C:red}稀有{}{C:attention}小丑{}",
 				},
 				small = {
-					"如果 {C:attention}盲注{} 是 {C:attention}小 {C:attention}盲注{}",
+					"如果{C:attention}盲注{}是{C:attention}小{C:attention}盲注{}",
 				},
 				spectral = {
-					"如果卡牌是 {C:spectral}幻灵{} 卡",
+					"如果卡牌是{C:spectral}幻灵牌{}",
 				},
 				suit = {
-					"如果卡牌是 {V:1}#3#{}",
+					"如果卡牌是{V:1}#3#{}",
 				},
 				tarot = {
-					"如果卡牌是 {C:tarot}塔罗{} 卡",
+					"如果卡牌是{C:tarot}塔罗牌{}",
 				},
 				uncommon = {
-					"如果是 {C:green}罕见{} {C:attention}小丑{}",
+					"如果是{C:green}罕见{}{C:attention}小丑{}",
 				},
 			},
 			contexts = {
 				after = {
-					"每个 {C:attention}手牌{} 后",
+					"每次{C:attention}出牌{}后",
 				},
 				before = {
-					"每个 {C:attention}手牌{} 前",
+					"每次{C:attention}出牌{}前",
 				},
 				buying_card = {
 					"购买卡牌时",
 				},
 				debuffed_hand = {
-					"如果已打出 {C:attention}手牌{} 被削弱",
+					"如果已打出{C:attention}手牌{}被削弱",
 				},
 				discard = {
 					"为每张丢弃的卡牌",
@@ -4097,7 +5287,7 @@ return {
 					"回合结束时",
 				},
 				ending_shop = {
-					"在 {C:attention}商店{} 结束时",
+					"在{C:attention}商店{}结束时",
 				},
 				first_hand_drawn = {
 					"回合开始时",
@@ -4113,13 +5303,13 @@ return {
 				},
 				joker_main = {},
 				open_booster = {
-					"当 {C:attention}补充包{} 被打开时",
+					"当{C:attention}补充包{}被打开时",
 				},
 				other_joker = {
-					"每个 {C:attention}小丑{}",
+					"每个{C:attention}小丑{}",
 				},
 				playing_card_added = {
-					"每次将 {C:attention}手牌{} 添加到牌组时",
+					"每次将{C:attention}手牌{}添加到牌组时",
 				},
 				pre_discard = {
 					"每次丢弃前",
@@ -4134,7 +5324,7 @@ return {
 					"重新触发已打出的卡牌",
 				},
 				reroll_shop = {
-					"重roll商店",
+					"重掷商店",
 				},
 				selling_card = {
 					"出售卡牌时",
@@ -4143,30 +5333,30 @@ return {
 					"出售此卡时",
 				},
 				setting_blind = {
-					"选择 {C:attention}盲注{} 时",
+					"选择{C:attention}盲注{}时",
 				},
 				skip_blind = {
-					"跳过 {C:attention}盲注{} 时",
+					"跳过{C:attention}盲注{}时",
 				},
 				skipping_booster = {
-					"跳过任何 {C:attention}补充包{} 时",
+					"跳过任何{C:attention}补充包{}时",
 				},
 				using_consumeable = {
-					"使用 {C:attention}消耗牌{} 卡牌时",
+					"使用{C:attention}消耗牌{}卡牌时",
 				},
 			},
 			stats = {
 				h_size = {
-					"{C:attention}+#2#{} 手牌数目",
+					"{C:attention}+#2#{}手牌数目",
 				},
 				money = {
-					"{C:money}+$#2#{} 金钱",
+					"{C:money}+$#2#{}金钱",
 				},
 				plus_chips = {
-					"{C:blue}+#2#{} 筹码",
+					"{C:blue}+#2#{}筹码",
 				},
 				plus_mult = {
-					"{C:red}+#2#{} 增加倍数",
+					"{C:red}+#2#{}增加倍数",
 				},
 				x_chips = {
 					"{X:blue,C:white} X#2#{} 筹码",
@@ -4249,8 +5439,8 @@ return {
 			},
 			cry_sticker_desc = {
 				"使用这张小丑在",
-				"#2#Stake#3# 难度",
-				"赢得 #2##1#",
+				"#2##1##2#注#3#",
+				"难度下获胜",
 			},
 			cry_sticker_name = {
 				"#1# 贴纸",
@@ -4258,19 +5448,19 @@ return {
 		},
 		v_text = {
 			ch_c_all_rnj = {
-				"所有小丑都是 {C:attention}RNJoker{}",
+				"所有小丑都是{C:attention}随机小丑{}",
 			},
 			ch_c_cry_all_banana = {
-				"所有小丑都是 {C:eternal}香蕉{}",
+				"所有小丑都是{C:eternal}香蕉{}",
 			},
 			ch_c_cry_all_perishable = {
-				"所有小丑都是 {C:eternal}易腐{}",
+				"所有小丑都是{C:eternal}易腐{}",
 			},
 			ch_c_cry_all_pinned = {
-				"所有小丑都是 {C:eternal}固定{}",
+				"所有小丑都是{C:eternal}固定{}",
 			},
 			ch_c_cry_all_rental = {
-				"所有小丑都是 {C:eternal}租赁{}",
+				"所有小丑都是{C:eternal}租赁{}",
 			},
 			ch_c_cry_no_boosters = {
 				"{C:attention}补充包{}不再出现在商店中",
@@ -4279,22 +5469,22 @@ return {
 				"不再出现{C:attention}消耗牌{} ",
 			},
 			ch_c_cry_no_rerolls = {
-				"禁止 {C:attention}重掷{}",
+				"禁止{C:attention}重掷{}",
 			},
 			ch_c_cry_no_tags = {
-				"跳过功能已 {C:attention}禁用{}",
+				"跳过功能已{C:attention}禁用{}",
 			},
 			ch_c_cry_no_vouchers = {
-				"{C:attention}优惠券{} 不再出现在商店中",
+				"{C:attention}优惠券{}不再出现在商店中",
 			},
 			ch_c_cry_rush_hour = {
-				"所有 Boss 盲注都是 {C:attention}时钟{} 或 {C:attention}薰衣草循环",
+				"所有Boss 盲注都是{C:attention}时钟{}或{C:attention}薰衣草循环",
 			},
 			ch_c_cry_rush_hour_ii = {
-				"所有盲注都是 {C:attention}Boss 盲注{}",
+				"所有盲注都是{C:attention}Boss 盲注{}",
 			},
 			ch_c_cry_rush_hour_iii = {
-				"{C:attention}时钟{} 和 {C:attention}薰衣草循环{} 的规模是 {C:attention}两倍{} 快",
+				"{C:attention}时钟{}和{C:attention}薰衣草循环{}的规模是{C:attention}两倍{}快",
 			},
 			ch_c_cry_sticker_sheet_plus = {
 				"所有可购买的物品都有所有贴纸",


### PR DESCRIPTION
在zh_CN.lua中添加对0.5.10~dev3的版本的对应翻译，添加大约72个小丑牌的中文描述和解锁条件，添加新更新的消耗牌的中文描述，以及大部分牌组、牌套、优惠券和消耗牌等等的解锁条件。添加了进入游戏时对游戏集的介绍的翻译。修正了之前翻译中部分小丑牌的错误描述。

Added translations of version 0.5.10~dev3 in zh_CN.lua, added Chinese descriptions and unlock conditions for about 72 Jokers, added Chinese descriptions for newly updated consumable cards, and unlocked conditions for most decks, sleeves, vouchers, consumable cards, etc. Added translations of the intro to the game set when entering the game. Fixed the incorrect descriptions of some Jokers in the previous translation.