### PR TITLE
Avoid use of any integer to float coercion in shaders to support mobile

### DIFF
--- a/assets/shaders/astral.fs
+++ b/assets/shaders/astral.fs
@@ -164,9 +164,9 @@ vec4 HSVtoRGB(vec4 hsv) {
 
 float bitxor(float val1, float val2)
 {
-	float outp = 0;
-	for(int i = 1; i < 9; i++) outp += floor(mod(mod(floor(val1*pow(2,-i)),pow(2,i))+mod(floor(val2*pow(2,-i)),pow(2,i)),2))*pow(2,i);
-	return outp/256;
+	float outp = 0.;
+	for(float i = 1.; i < 9.; i++) outp += floor(mod(mod(floor(val1*pow(2.,-i)),pow(2.,i))+mod(floor(val2*pow(2.,-i)),pow(2.,i)),2.))*pow(2.,i);
+	return outp/256.;
 }
 
 float mod2(float val1, float mod1)
@@ -183,7 +183,7 @@ float rand(vec2 c){
 }
 
 float noise(vec2 p, float freq ){
-	float unit = 1/freq;
+	float unit = 1./freq;
 	vec2 ij = floor(p/unit);
 	vec2 xy = mod(p,unit)/unit;
 	//xy = 3.*xy*xy-2.*xy*xy*xy;
@@ -249,8 +249,8 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 
     vec4 pixel = Texel(texture, texture_coords);
 
-    float cx = uv_scaled_centered.x * 1;
-    float cy = uv_scaled_centered.y * 1;
+    float cx = uv_scaled_centered.x * 1.;
+    float cy = uv_scaled_centered.y * 1.;
 
 
 
@@ -263,8 +263,8 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 
     vec2 mouse_offset = (screen_coords.xy - mouse_screen_pos.xy)/screen_scale;
 
-    float scaled_uvy = (uv.y +mouse_offset.y -0.5)*5*1.338;
-    float scaled_uvx = (uv.x +mouse_offset.x -0.5)*5;
+    float scaled_uvy = (uv.y +mouse_offset.y -0.5)*5.*1.338;
+    float scaled_uvx = (uv.x +mouse_offset.x -0.5)*5.;
     float norm_uv = sqrt(scaled_uvx*scaled_uvx + scaled_uvy*scaled_uvy);
 
     pixel = vec4(pixel.rgb * 0.0 + tex.rgb * tex.a, pixel.a);
@@ -273,17 +273,17 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
     vec4 textp = RGB(hsl);
     tex.rgb = textp.rgb;
 
-	float stars = ((pNoise(uv*10 + t/15.0, 10)*pNoise(uv*10 + t/15.0, 10)+1.5)/1+0.15 + ((pNoise(uv*12 + t/15.0, 10)+1.2)/1+0.3))/2.2+0.05 + 0.007*norm_uv * 1.1;
+	float stars = ((pNoise(uv*10. + t/15.0, 10)*pNoise(uv*10. + t/15.0, 10)+1.5)/1.+0.15 + ((pNoise(uv*12. + t/15.0, 10)+1.2)/1.+0.3))/2.2+0.05 + 0.007*norm_uv * 1.1;
 
 	float clusters = (pNoise(uv*10.0-t/15.0, 10)+1.5)/1.5-0.25 + 0.007*norm_uv;
 
-	float super_clusters = (pNoise(uv/15.0, 10)+0.1)/2+0.3 - 0.008*norm_uv;
+	float super_clusters = (pNoise(uv/15.0, 10)+0.1)/2.+0.3 - 0.008*norm_uv;
 
     clusters *= clusters * clusters * clusters * 0.4;
     stars *= stars * stars;
     super_clusters *= super_clusters * super_clusters;
 
-	colour.rgb = vec3(0.6, 0.45, 1) * (((clusters + stars + super_clusters)+0.1)) * 0.285;
+	colour.rgb = vec3(0.6, 0.45, 1.) * (((clusters + stars + super_clusters)+0.1)) * 0.285;
 
 	return dissolve_mask(tex*colour, texture_coords, uv);
 }
@@ -299,6 +299,6 @@ vec4 position( mat4 transform_projection, vec4 vertex_position )
     float scale = 0.2*(-0.03 - 0.3*max(0., 0.3-mid_dist))
                 *hovering*(length(mouse_offset)*length(mouse_offset))/(2. -mid_dist);
 
-    return transform_projection * vertex_position + vec4(0,0,0,scale);
+    return transform_projection * vertex_position + vec4(0.,0.,0.,scale);
 }
 #endif

--- a/assets/shaders/blur.fs
+++ b/assets/shaders/blur.fs
@@ -179,6 +179,6 @@ vec4 position( mat4 transform_projection, vec4 vertex_position )
     float scale = 0.2*(-0.03 - 0.3*max(0., 0.3-mid_dist))
                 *hovering*(length(mouse_offset)*length(mouse_offset))/(2. -mid_dist);
 
-    return transform_projection * vertex_position + vec4(0,0,0,scale);
+    return transform_projection * vertex_position + vec4(0.,0.,0.,scale);
 }
 #endif

--- a/assets/shaders/glass.fs
+++ b/assets/shaders/glass.fs
@@ -104,6 +104,6 @@ vec4 position( mat4 transform_projection, vec4 vertex_position )
     float scale = 0.2*(-0.03 - 0.3*max(0., 0.3-mid_dist))
                 *hovering*(length(mouse_offset)*length(mouse_offset))/(2. -mid_dist);
 
-    return transform_projection * vertex_position + vec4(0,0,0,scale);
+    return transform_projection * vertex_position + vec4(0.,0.,0.,scale);
 }
 #endif

--- a/assets/shaders/glitched.fs
+++ b/assets/shaders/glitched.fs
@@ -139,6 +139,6 @@ vec4 position( mat4 transform_projection, vec4 vertex_position )
     float scale = 0.2*(-0.03 - 0.3*max(0., 0.3-mid_dist))
                 *hovering*(length(mouse_offset)*length(mouse_offset))/(2. -mid_dist);
 
-    return transform_projection * vertex_position + vec4(0,0,0,scale);
+    return transform_projection * vertex_position + vec4(0.,0.,0.,scale);
 }
 #endif

--- a/assets/shaders/glitched_b.fs
+++ b/assets/shaders/glitched_b.fs
@@ -161,9 +161,9 @@ vec4 HSVtoRGB(vec4 hsv) {
 
 float bitxor(float val1, float val2)
 {
-	float outp = 0;
-	for(int i = 1; i < 9; i++) outp += floor(mod(mod(floor(val1*pow(2,-i)),pow(2,i))+mod(floor(val2*pow(2,-i)),pow(2,i)),2))*pow(2,i);
-	return outp/256;
+	float outp = 0.;
+	for(float i = 1.; i < 9.; i++) outp += floor(mod(mod(floor(val1*pow(2.,-i)),pow(2.,i))+mod(floor(val2*pow(2.,-i)),pow(2.,i)),2.))*pow(2.,i);
+	return outp/256.;
 }
 
 float mod2(float val1, float mod1)
@@ -207,18 +207,18 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 
     vec4 pixel = Texel(texture, texture_coords);
 
-    float cx = uv_scaled_centered.x * 1;
-    float cy = uv_scaled_centered.y * 1;
+    float cx = uv_scaled_centered.x * 1.;
+    float cy = uv_scaled_centered.y * 1.;
 
-	float randnum = mod2(floor(4*t), 256)*mod2(floor(4*t), 27);
-	randnum = mod2(bitxor(pow(randnum, 3) - randnum + 3, 7 + floor(randnum/11)), 256);
-	randnum = mod2(randnum*123.54,0.1)*10;
+	float randnum = mod2(floor(4.*t), 256.)*mod2(floor(4.*t), 27.);
+	randnum = mod2(bitxor(pow(randnum, 3.) - randnum + 3., 7. + floor(randnum/11.)), 256.);
+	randnum = mod2(randnum*123.54,0.1)*10.;
 
 
 
     vec4 hsl = HSL(vec4(tex.r, tex.g, tex.b, tex.a));
 
-    float xorscale = 10;
+    float xorscale = 10.;
 
     // |y| = 50, |x| = 50
 
@@ -226,29 +226,29 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
     float mby;
     float offx;
     float offy;
-    float rmasksum = -1;
-    float rectmask = 1;
-    t = floor(t/4);
+    float rmasksum = -1.;
+    float rectmask = 1.;
+    t = floor(t/4.);
 
-    for(int i = 0; i < 5; i++)
+    for(float i = 0.; i < 5.; i++)
     {     
-        randnum = bitxor(255*randnum + mod2(t,81), pow(randnum*(16-i), 2));
-        mbx = (cx - 25*sin(100/randnum)) * (1 + 2*(floor(cos(177/randnum + 1))));
-        mby = (cy - 25*cos(113/randnum + 1)) * (1 + 2*(floor(sin(221/randnum))));
-        offx = bitxor(255*randnum, pow(255*randnum,5) - 255*randnum);
-        offy = bitxor(255*randnum, pow(255*randnum,5) + 255*randnum);
-        offx /= 10;
-        offy /= 10;
+        randnum = bitxor(255.*randnum + mod2(t,81.), pow(randnum*(16.-i), 2.));
+        mbx = (cx - 25.*sin(100./randnum)) * (1. + 2.*(floor(cos(177./randnum + 1.))));
+        mby = (cy - 25.*cos(113./randnum + 1.)) * (1. + 2.*(floor(sin(221./randnum))));
+        offx = bitxor(255.*randnum, pow(255.*randnum,5.) - 255.*randnum);
+        offy = bitxor(255.*randnum, pow(255.*randnum,5.) + 255.*randnum);
+        offx /= 10.;
+        offy /= 10.;
         rectmask = (-mbx + abs(abs(mbx) + offx) - offx) - (mby - abs(abs(mby) - offy) + offy);
-        rmasksum *= -1 * min(0, max(-1, 5 - pow(rectmask, 2)));
+        rmasksum *= -1. * min(0., max(-1., 5. - pow(rectmask, 2.)));
     }
 
-    float laddermask = pow(sin((23-20*randnum*randnum)*pow(sin(sin(cy*randnum) + pow(sin(cy*randnum),2)),2)),2) * rmasksum;
+    float laddermask = pow(sin((23.-20.*randnum*randnum)*pow(sin(sin(cy*randnum) + pow(sin(cy*randnum),2.)),2.)),2.) * rmasksum;
     
 
-	hsl.x += floor(randnum + 0.1) * rmasksum * 4 * randnum * (1 - laddermask);// * bitxor(cx * xorscale, cy * xorscale)/4;
-    hsl.y += laddermask * (1 + 2 * rmasksum); 
-    hsl.z += floor(randnum + 0.2) * (1 + rmasksum) * (1 - 1.5*hsl.z) * 0.1;
+	hsl.x += floor(randnum + 0.1) * rmasksum * 4. * randnum * (1. - laddermask);// * bitxor(cx * xorscale, cy * xorscale)/4;
+    hsl.y += laddermask * (1. + 2. * rmasksum); 
+    hsl.z += floor(randnum + 0.2) * (1. + rmasksum) * (1. - 1.5*hsl.z) * 0.1;
 
     tex.rgb = RGB(hsl).rgb;
 
@@ -277,6 +277,6 @@ vec4 position( mat4 transform_projection, vec4 vertex_position )
     float scale = 0.2*(-0.03 - 0.3*max(0., 0.3-mid_dist))
                 *hovering*(length(mouse_offset)*length(mouse_offset))/(2. -mid_dist);
 
-    return transform_projection * vertex_position + vec4(0,0,0,scale);
+    return transform_projection * vertex_position + vec4(0.,0.,0.,scale);
 }
 #endif

--- a/assets/shaders/gold.fs
+++ b/assets/shaders/gold.fs
@@ -109,6 +109,6 @@ vec4 position( mat4 transform_projection, vec4 vertex_position )
     float scale = 0.2*(-0.03 - 0.3*max(0., 0.3-mid_dist))
                 *hovering*(length(mouse_offset)*length(mouse_offset))/(2. -mid_dist);
 
-    return transform_projection * vertex_position + vec4(0,0,0,scale);
+    return transform_projection * vertex_position + vec4(0.,0.,0.,scale);
 }
 #endif

--- a/assets/shaders/m.fs
+++ b/assets/shaders/m.fs
@@ -130,6 +130,6 @@ vec4 position( mat4 transform_projection, vec4 vertex_position )
     float scale = 0.2*(-0.03 - 0.3*max(0., 0.3-mid_dist))
                 *hovering*(length(mouse_offset)*length(mouse_offset))/(2. -mid_dist);
 
-    return transform_projection * vertex_position + vec4(0,0,0,scale);
+    return transform_projection * vertex_position + vec4(0.,0.,0.,scale);
 }
 #endif

--- a/assets/shaders/mosaic.fs
+++ b/assets/shaders/mosaic.fs
@@ -145,6 +145,6 @@ vec4 position( mat4 transform_projection, vec4 vertex_position )
     float scale = 0.2*(-0.03 - 0.3*max(0., 0.3-mid_dist))
                 *hovering*(length(mouse_offset)*length(mouse_offset))/(2. -mid_dist);
 
-    return transform_projection * vertex_position + vec4(0,0,0,scale);
+    return transform_projection * vertex_position + vec4(0.,0.,0.,scale);
 }
 #endif

--- a/assets/shaders/noisy.fs
+++ b/assets/shaders/noisy.fs
@@ -88,6 +88,6 @@ vec4 position( mat4 transform_projection, vec4 vertex_position )
     float scale = 0.2*(-0.03 - 0.3*max(0., 0.3-mid_dist))
                 *hovering*(length(mouse_offset)*length(mouse_offset))/(2. -mid_dist);
 
-    return transform_projection * vertex_position + vec4(0,0,0,scale);
+    return transform_projection * vertex_position + vec4(0.,0.,0.,scale);
 }
 #endif

--- a/assets/shaders/oversat.fs
+++ b/assets/shaders/oversat.fs
@@ -222,6 +222,6 @@ vec4 position( mat4 transform_projection, vec4 vertex_position )
     float scale = 0.2*(-0.03 - 0.3*max(0., 0.3-mid_dist))
                 *hovering*(length(mouse_offset)*length(mouse_offset))/(2. -mid_dist);
 
-    return transform_projection * vertex_position + vec4(0,0,0,scale);
+    return transform_projection * vertex_position + vec4(0.,0.,0.,scale);
 }
 #endif

--- a/assets/shaders/ultrafoil.fs
+++ b/assets/shaders/ultrafoil.fs
@@ -152,6 +152,6 @@ vec4 position( mat4 transform_projection, vec4 vertex_position )
     float scale = 0.2*(-0.03 - 0.3*max(0., 0.3-mid_dist))
                 *hovering*(length(mouse_offset)*length(mouse_offset))/(2. -mid_dist);
 
-    return transform_projection * vertex_position + vec4(0,0,0,scale);
+    return transform_projection * vertex_position + vec4(0.,0.,0.,scale);
 }
 #endif


### PR DESCRIPTION
Prevents the following error (and similar) when attempting to load the mod in mobile.
```
Oops! The game crashed: 
Error validating vertex shader code: 
Line 167: ERROR: '=': cannot convert from 
'const int' to ' temp highp float' 
Line 167: ERROR: ": compilation 
terminated 
ERROR: 2 compilation errors. No code 
generated. 
```