### PR TITLE
Fix Cardless Decks Freezing

### DIFF
--- a/lib/overrides.lua
+++ b/lib/overrides.lua
@@ -1816,10 +1816,7 @@ end
 
 local end_roundref = end_round
 function end_round()
-	if
-		((#G.hand.cards < 1 and #G.deck.cards < 1 and #G.play.cards < 1) or (#G.hand.cards < 1 and #G.deck.cards < 1))
-		and G.STATE ~= G.STATES.NEW_ROUND
-	then
+	if (#G.hand.cards < 1 and #G.deck.cards < 1 and #G.play.cards < 1) or (#G.hand.cards < 1 and #G.deck.cards < 1) then
 		if
 			Cryptid.enabled("set_cry_poker_hand_stuff") == true
 			and not Cryptid.safe_get(G.PROFILES, G.SETTINGS.profile, "cry_none")
@@ -1829,7 +1826,6 @@ function end_round()
 		if not Cryptid.enabled("set_cry_poker_hand_stuff") then
 			end_roundref()
 		end
-	else
 		end_roundref()
 	end
 	G.E_MANAGER:add_event(Event({


### PR DESCRIPTION
The new version made Cardless decks impossible due to it freezing after you reach the desired score. :p