### PR TITLE
Make Duplicare only trigger in probability contexts on roll

### DIFF
--- a/items/exotic.lua
+++ b/items/exotic.lua
@@ -1462,7 +1462,11 @@ local duplicare = {
 		if
 			not context.blueprint
 			and (
-				(context.post_trigger and context.other_joker ~= card)
+				(
+					context.post_trigger
+					and context.other_joker ~= card
+					and Cryptid.isNonRollProbabilityContext(context.other_context)
+				)
 				or (context.individual and context.cardarea == G.play)
 			)
 		then

--- a/lib/misc.lua
+++ b/lib/misc.lua
@@ -1457,3 +1457,18 @@ function Cryptid.get_next_tag(override)
 		return "tag_cry_cat"
 	end
 end
+
+-- for Cryptid.isNonRollProbabilityContext
+local probability_contexts = {
+	"mod_probability",
+	"fix_probability"
+}
+
+-- Checks if a context table is a probability context called outside of a roll
+function Cryptid.isNonRollProbabilityContext(context)
+	for _, ctx in ipairs(probability_contexts) do
+		if context[ctx] then return context.from_roll end
+	end
+
+	return true
+end


### PR DESCRIPTION
made duplicare only trigger from `context.mod_probability` and `context.fix_probability` when a probability is rolled.