### PR TITLE
fix: semicolon code

### DIFF
--- a/items/code.lua
+++ b/items/code.lua
@@ -4515,7 +4515,7 @@ local semicolon = {
 			"HexaCryonic",
 		},
 		code = {
-			"Math",
+			"WilsontheWolf",
 		},
 	},
 	dependencies = {


### PR DESCRIPTION
Was just checking this code for reference and realized it was mistakenly credited to Math. I wrote the code for this (https://github.com/SpectralPack/Cryptid/pull/40)