### PR TITLE
fix encoded deck unlock

### DIFF
--- a/items/pointer.lua
+++ b/items/pointer.lua
@@ -44,6 +44,12 @@ local pointer = {
 				return true
 			end,
 		}))
+		G.E_MANAGER:add_event(Event({
+			func = function()
+				check_for_unlock({ cry_used_consumable = "c_cry_pointer" })
+				return true
+			end,
+		}))
 		G.GAME.POINTER_SUBMENU = nil
 	end,
 	init = function(self)
@@ -2643,7 +2649,7 @@ local aliases = {
 	-- Cryptid T3 Vouchers
 	-- super strong placeholder
 
-	--[[ 
+	--[[
 	Format:
 		<joker key> = {
 			"<alias1>",


### PR DESCRIPTION
this fixes the unlock for pointer, which is currently broken as multiple people in the discord server have pointed out
anyways i noticed a lot of unlocks causes the game to become unresponsive while the unlock popup is visible, idk what causes it but that's out of scope for this pr
