### PR TITLE
Fix blueprint compat

### DIFF
--- a/items/epic.lua
+++ b/items/epic.lua
@@ -936,6 +936,7 @@ local number_blocks = {
 	rarity = "cry_epic",
 	cost = 14,
 	order = 12,
+	blueprint_compat = false,
 	atlas = "atlasepic",
 	loc_vars = function(self, info_queue, center)
 		return {

--- a/items/exotic.lua
+++ b/items/exotic.lua
@@ -411,6 +411,7 @@ local tenebris = {
 	cost = 50,
 	order = 507,
 	atlas = "atlasexotic",
+	blueprint_compat = false,
 	demicoloncompat = true,
 	calc_dollar_bonus = function(self, card)
 		return lenient_bignum(card.ability.extra.money)


### PR DESCRIPTION
Set `blueprint_compat` to `false` for jokers that give money at the end of round