### PR TITLE
Add a safety check to Thematic Sets UI in in-game config settings

### DIFF
--- a/Cryptid.lua
+++ b/Cryptid.lua
@@ -356,7 +356,9 @@ G.FUNCS.update_cry_members = function(...)
 end
 
 local cryptidConfigTab = function()
-	cry_nodes = {
+	local has_ongoing_run = (G.STAGE == G.STAGES.RUN)
+		or (not not (G.SETTINGS and G.SETTINGS.profile and love.filesystem.getInfo(G.SETTINGS.profile .. "/" .. "save.jkr")))
+	local cry_nodes = {
 		{
 			n = G.UIT.R,
 			config = { align = "cm" },
@@ -375,13 +377,32 @@ local cryptidConfigTab = function()
 			},
 		},
 	}
-	left_settings = { n = G.UIT.C, config = { align = "tl", padding = 0.05 }, nodes = {} }
-	right_settings = { n = G.UIT.C, config = { align = "tl", padding = 0.05 }, nodes = {} }
-	config = { n = G.UIT.R, config = { align = "tm", padding = 0 }, nodes = { left_settings, right_settings } }
+	if has_ongoing_run then
+		cry_nodes[#cry_nodes + 1] = {
+			n = G.UIT.R,
+			config = { align = "cm" },
+			nodes = {
+				{
+					n = G.UIT.O,
+					config = {
+						object = DynaText({
+							string = localize("cry_set_thematic_ongoing_warning"),
+							colours = { G.C.RED },
+							shadow = true,
+							scale = 0.32,
+						}),
+					},
+				},
+			},
+		}
+	end
+	local left_settings = { n = G.UIT.C, config = { align = "tl", padding = 0.05 }, nodes = {} }
+	local right_settings = { n = G.UIT.C, config = { align = "tl", padding = 0.05 }, nodes = {} }
+	local config = { n = G.UIT.R, config = { align = "tm", padding = 0 }, nodes = { left_settings, right_settings } }
 	cry_nodes[#cry_nodes + 1] = config
 	cry_nodes[#cry_nodes + 1] = UIBox_button({
-		colour = G.C.CRY_GREENGRADIENT,
-		button = "your_collection_content_sets",
+		colour = has_ongoing_run and G.C.UI.BACKGROUND_INACTIVE or G.C.CRY_GREENGRADIENT,
+		button = has_ongoing_run and "nil" or "your_collection_content_sets",
 		label = { localize("b_content_sets") },
 		count = modsCollectionTally(G.P_CENTER_POOLS["Content Set"]),
 		minw = 5,

--- a/lib/gameset.lua
+++ b/lib/gameset.lua
@@ -1395,6 +1395,11 @@ SMODS.ContentSet({
 
 -- these are mostly copy/paste from vanilla code
 G.FUNCS.your_collection_content_sets = function(e)
+	local has_ongoing_run = (G.STAGE == G.STAGES.RUN)
+		or (not not (G.SETTINGS and G.SETTINGS.profile and love.filesystem.getInfo(G.SETTINGS.profile .. "/" .. "save.jkr")))
+	if has_ongoing_run then
+		return
+	end
 	G.cry_prev_collec = "your_collection_content_sets"
 	G.SETTINGS.paused = true
 	G.FUNCS.overlay_menu({

--- a/localization/de.lua
+++ b/localization/de.lua
@@ -4982,6 +4982,7 @@ return {
 			cry_set_features = "Features",
 			cry_set_music = "Musik",
 			cry_set_enable_features = "Aktiviere oder Deaktiviere ganze Thematische Sets",
+			cry_set_thematic_ongoing_warning = "(Thematische Sets können während eines laufenden Spiels nicht umgeschaltet werden. Bitte beende das Spiel, um auf diesen Bereich zuzugreifen)",
 			cry_feat_achievements = "Erfolge",
 			["cry_feat_antimatter deck"] = "Antimaterie-Deck",
 			cry_feat_blinds = "Blinds",

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -5199,6 +5199,7 @@ return {
 			cry_set_features = "Features",
 			cry_set_music = "Music",
 			cry_set_enable_features = "Use this section to enable or disable entire Thematic Sets.",
+			cry_set_thematic_ongoing_warning = "(Thematic sets cannot be toggled while you have an ongoing game. Please finish the game to access this section)",
 			cry_feat_achievements = "Achievements",
 			["cry_feat_antimatter deck"] = "Antimatter Deck",
 			cry_feat_blinds = "Blinds",

--- a/localization/es_419.lua
+++ b/localization/es_419.lua
@@ -3527,6 +3527,7 @@ return {
 			cry_set_features = "Características",
 			cry_set_music = "Música",
 			cry_set_enable_features = "Selecciona las características para activar (se aplica al reiniciar):",
+			cry_set_thematic_ongoing_warning = "(Los sets temáticos no se pueden alternar durante una partida en curso. Por favor, termina la partida para acceder a esta sección)",
 			cry_feat_achievements = "Logros",
 			["cry_feat_antimatter deck"] = "Baraja de antimateria",
 			cry_feat_blinds = "Ciegas",

--- a/localization/es_ES.lua
+++ b/localization/es_ES.lua
@@ -4514,6 +4514,7 @@ return {
 			cry_set_features = "Características",
 			cry_set_music = "Música",
 			cry_set_enable_features = "Usa esta sección para activar o desactivar sets temáticos.",
+			cry_set_thematic_ongoing_warning = "(Los sets temáticos no se pueden alternar durante una partida en curso. Por favor, termina la partida para acceder a esta sección)",
 			cry_feat_achievements = "Logros",
 			["cry_feat_antimatter deck"] = "Baraja de antimateria",
 			cry_feat_blinds = "Ciegas",

--- a/localization/fr.lua
+++ b/localization/fr.lua
@@ -5047,6 +5047,7 @@ return {
 			cry_set_features = "Fonctionnalités",
 			cry_set_music = "Musique",
 			cry_set_enable_features = "Utilisez cette section pour activer ou désactiver des Sets thématiques tout entier.",
+			cry_set_thematic_ongoing_warning = "(Les sets thématiques ne peuvent pas être modifiés pendant une partie en cours. Veuillez terminer la partie pour accéder à cette section)",
 			cry_feat_achievements = "Succès",
 			["cry_feat_antimatter deck"] = "Jeu Anti-matière",
 			cry_feat_blinds = "Blindes",

--- a/localization/id.lua
+++ b/localization/id.lua
@@ -3010,6 +3010,7 @@ return {
 			cry_set_features = "Features",
 			cry_set_music = "Music",
 			cry_set_enable_features = "Select features to enable (applies on game restart):",
+			cry_set_thematic_ongoing_warning = "(Set tematik tidak dapat diubah saat permainan sedang berlangsung. Selesaikan permainan untuk mengakses bagian ini)",
 			cry_feat_achievements = "Achievements",
 			["cry_feat_antimatter deck"] = "Antimatter Deck",
 			cry_feat_blinds = "Blinds",

--- a/localization/ja.lua
+++ b/localization/ja.lua
@@ -5167,6 +5167,7 @@ return {
 			cry_set_features = "機能",
 			cry_set_music = "BGM",
 			cry_set_enable_features = "このセクションでは特定のテーマのセットを無効／有効にできます",
+			cry_set_thematic_ongoing_warning = "(ゲーム進行中はテーマセットを切り替えることはできません。このセクションにアクセスするにはゲームを終了してください)",
 			cry_feat_achievements = "アチーブメント",
 			["cry_feat_antimatter deck"] = "Antimatter Deck",
 			cry_feat_blinds = "ブラインド",

--- a/localization/ko.lua
+++ b/localization/ko.lua
@@ -5027,6 +5027,7 @@ return {
 			cry_set_features = "기능",
 			cry_set_music = "음악",
 			cry_set_enable_features = "이 섹션을 사용하여 전체 테마 세트를 활성화하거나 비활성화하세요.",
+			cry_set_thematic_ongoing_warning = "(진행 중인 게임이 있는 동안에는 테마 세트를 전환할 수 없습니다. 이 섹션에 접근하려면 게임을 완료하세요)",
 			cry_feat_achievements = "업적",
 			["cry_feat_antimatter deck"] = "반물질 덱",
 			cry_feat_blinds = "블라인드",

--- a/localization/nl.lua
+++ b/localization/nl.lua
@@ -3016,6 +3016,7 @@ return {
 			cry_set_features = "Features",
 			cry_set_music = "Music",
 			cry_set_enable_features = "Select features to enable (applies on game restart):",
+			cry_set_thematic_ongoing_warning = "(Thematische sets kunnen niet worden gewijzigd tijdens een lopend spel. Voltooi het spel om toegang te krijgen tot deze sectie)",
 			cry_feat_achievements = "Achievements",
 			["cry_feat_antimatter deck"] = "Antimatter Deck",
 			cry_feat_blinds = "Blinds",

--- a/localization/pl.lua
+++ b/localization/pl.lua
@@ -3616,6 +3616,7 @@ return {
 			cry_set_features = "Funkcje",
 			cry_set_music = "Muzyka",
 			cry_set_enable_features = "Wybierz funkcje do włączenia (zastosują się po ponownym uruchomieniu gry):",
+			cry_set_thematic_ongoing_warning = "(Zestawy tematyczne nie mogą być przełączane podczas trwającej gry. Ukończ grę, aby uzyskać dostęp do tej sekcji)",
 			cry_feat_achievements = "Wyzwania",
 			["cry_feat_antimatter deck"] = "Talia Antymateryjna",
 			cry_feat_blinds = "Przeszkadzajki",

--- a/localization/pt_BR.lua
+++ b/localization/pt_BR.lua
@@ -4440,6 +4440,7 @@ return {
 			cry_set_features = "Features",
 			cry_set_music = "Music",
 			cry_set_enable_features = "Use this section to enable or disable entire Thematic Sets.",
+			cry_set_thematic_ongoing_warning = "(Os conjuntos temáticos não podem ser alterados durante uma partida em andamento. Por favor, termine a partida para acessar esta seção)",
 			cry_feat_achievements = "Achievements",
 			["cry_feat_antimatter deck"] = "Antimatter Deck",
 			cry_feat_blinds = "Blinds",

--- a/localization/ru.lua
+++ b/localization/ru.lua
@@ -4006,6 +4006,7 @@ return {
 			cry_set_features = "Функции",
 			cry_set_music = "Музыка",
 			cry_set_enable_features = "Выберите функции для включения (применяются при перезапуске игры):",
+			cry_set_thematic_ongoing_warning = "(Тематические наборы нельзя переключать во время текущей игры. Пожалуйста, завершите игру, чтобы получить доступ к этому разделу)",
 			cry_feat_spooky = "Жуткое обновление",
 			cry_feat_achievements = "Достижения",
 			["cry_feat_antimatter deck"] = "Колода антиматерии",

--- a/localization/vi.lua
+++ b/localization/vi.lua
@@ -4231,6 +4231,7 @@ return {
 			cry_set_features = "Tính Năng",
 			cry_set_music = "Nhạc",
 			cry_set_enable_features = "Chọn tính năng để dùng (áp dụng khi khởi động lại trò chơi):",
+			cry_set_thematic_ongoing_warning = "(Không thể chuyển đổi bộ chủ đề khi đang có một ván chơi. Vui lòng kết thúc trò chơi để truy cập phần này)",
 			cry_feat_achievements = "Thành Tựu",
 			["cry_feat_antimatter deck"] = "Bộ Bài Phản Vật Chất",
 			cry_feat_blinds = "Blind",

--- a/localization/zh_CN.lua
+++ b/localization/zh_CN.lua
@@ -5024,6 +5024,7 @@ return {
 			cry_set_features = "功能",
 			cry_set_music = "音乐",
 			cry_set_enable_features = "使用此选项卡来启用或禁用整个主题集合。",
+			cry_set_thematic_ongoing_warning = "(进行游戏时无法切换主题集合。请先结束游戏以访问此部分)",
 			cry_feat_achievements = "成就",
 			["cry_feat_antimatter deck"] = "反物质牌组",
 			cry_feat_blinds = "盲注",

--- a/localization/zh_TW.lua
+++ b/localization/zh_TW.lua
@@ -3009,6 +3009,7 @@ return {
 			cry_set_features = "Features",
 			cry_set_music = "Music",
 			cry_set_enable_features = "Select features to enable (applies on game restart):",
+			cry_set_thematic_ongoing_warning = "(進行遊戲時無法切換主題集合。請先結束遊戲以訪問此部分)",
 			cry_feat_achievements = "Achievements",
 			["cry_feat_antimatter deck"] = "Antimatter Deck",
 			cry_feat_blinds = "Blinds",


### PR DESCRIPTION
Disallow the player to access the Thematic Sets menu section while they have an ongoing run to prevent crashes/unstable behavior.