### PR TITLE
Fix fragile edition

### DIFF
--- a/Cryptid.json
+++ b/Cryptid.json
@@ -12,7 +12,7 @@
 	"version": "0.5.17~dev",
 	"dependencies": [
 		"Amulet (>=2.7)",
-		"Steamodded (>=1.0.0~BETA-2008b)"
+		"Steamodded (>=1.0.0~BETA-2010b)"
 	],
 	"conflicts": [
 		"AntePreview (>= 2.0.0~0c16a) (<<3.0.0)",

--- a/items/misc.lua
+++ b/items/misc.lua
@@ -1869,7 +1869,7 @@ local glass_edition = {
 			and context.other_card == card --animation-wise this looks weird sometimes
 			and Cryptid.isNonRollProbabilityContext(context.other_context)
 		then
-			local shatter_chance = card and card.edition and card.edition.shatter_chance or self.config.shatter_chance
+			local shatter_chance = card.edition.shatter_chance or self.config.shatter_chance
 			if
 				not SMODS.is_eternal(card)
 				and not SMODS.pseudorandom_probability(
@@ -1886,11 +1886,11 @@ local glass_edition = {
 			end
 		end
 		if context.main_scoring and context.cardarea == G.play then
-			return { x_mult = card and card.edition and card.edition.x_mult or self.config.x_mult }
+			return { x_mult = card.edition.x_mult or self.config.x_mult }
 		end
 
 		if context.destroy_card and context.destroy_card == card and context.cardarea == G.play then
-			local shatter_chance = card and card.edition and card.edition.shatter_chance or self.config.shatter_chance
+			local shatter_chance = card.edition.shatter_chance or self.config.shatter_chance
 			if
 				not SMODS.is_eternal(card)
 				and not SMODS.pseudorandom_probability(

--- a/items/misc.lua
+++ b/items/misc.lua
@@ -1867,14 +1867,16 @@ local glass_edition = {
 			context.cardarea == G.jokers
 			and context.post_trigger
 			and context.other_card == card --animation-wise this looks weird sometimes
+			and Cryptid.isNonRollProbabilityContext(context.other_context)
 		then
+			local shatter_chance = card and card.edition and card.edition.shatter_chance or self.config.shatter_chance
 			if
 				not SMODS.is_eternal(card)
 				and not SMODS.pseudorandom_probability(
 					card,
 					"cry_fragile",
-					card.edition.shatter_chance - 1,
-					card.edition.shatter_chance,
+					shatter_chance - 1,
+					shatter_chance,
 					nil,
 					true
 				)
@@ -1884,24 +1886,24 @@ local glass_edition = {
 			end
 		end
 		if context.main_scoring and context.cardarea == G.play then
+			return { x_mult = card and card.edition and card.edition.x_mult or self.config.x_mult }
+		end
+
+		if context.destroy_card and context.destroy_card == card and context.cardarea == G.play then
+			local shatter_chance = card and card.edition and card.edition.shatter_chance or self.config.shatter_chance
 			if
 				not SMODS.is_eternal(card)
-				and SMODS.pseudorandom_probability(
+				and not SMODS.pseudorandom_probability(
 					card,
 					"cry_fragile",
-					card.edition.shatter_chance - 1,
-					card.edition.shatter_chance,
+					shatter_chance - 1,
+					shatter_chance,
 					nil,
 					true
 				)
 			then
-				card.config.will_shatter = true
+				return { remove = true }
 			end
-			return { x_mult = self.config.x_mult }
-		end
-
-		if context.destroy_card and context.destroy_card == card and card.config.will_shatter then
-			return { remove = true }
 		end
 	end,
 	attributes = { "chance", "destroy_card", "xmult" },

--- a/lib/calculate.lua
+++ b/lib/calculate.lua
@@ -21,9 +21,6 @@ function eval_card(card, context)
 			end,
 		}
 	end
-	if card.will_shatter then
-		return {}, {}
-	end
 	-- Store old probability for later reference
 	local ret, post = ec(card, context)
 	return ret, post

--- a/lib/overrides.lua
+++ b/lib/overrides.lua
@@ -1611,34 +1611,15 @@ function Card:get_id()
 	return vars
 end
 
--- Hook SMODS.shatters to support editions with shatters = true (e.g. Fragile) or cards marked with will_shatter
-local smods_shatters = SMODS.shatters
-function SMODS.shatters(card)
-	if card then
-		if
-			card.edition
-			and (
-				card.edition.shatters
-				or (G.P_CENTERS and card.edition.key and G.P_CENTERS[card.edition.key] and G.P_CENTERS[card.edition.key].shatters)
-				or card.edition.cry_glass
-			)
-		then
-			return true
-		end
-		if card.shatters or card.will_shatter then
-			return true
-		end
-	end
-	return smods_shatters(card)
-end
-
 --override shatter function to adjust volume (it has been requested that at end of deck, abstract cards should shatter a bit quieter)
 function Card:shatter(volume)
 	local dissolve_time = 0.7
 	self.shattered = true
 	self.dissolve = 0
 	self.dissolve_colours = { { 1, 1, 1, 0.8 } }
-	self:juice_up()
+	if type(volume) ~= "table" or not volume.no_juice then
+		self:juice_up()
+	end
 	local childParts = Particles(0, 0, 0, 0, {
 		timer_type = "TOTAL",
 		timer = 0.007 * dissolve_time,
@@ -1661,8 +1642,12 @@ function Card:shatter(volume)
 	G.E_MANAGER:add_event(Event({
 		blockable = false,
 		func = function()
-			play_sound("glass" .. math.random(1, 6), math.random() * 0.2 + 0.9, volume or 0.5)
-			play_sound("generic1", math.random() * 0.2 + 0.9, volume or 0.5)
+			local silent = type(volume) == "table" and volume.silent
+			if not silent then
+				local vol = (type(volume) == "number" and volume) or (type(volume) == "table" and volume.volume) or 0.5
+				play_sound("glass" .. math.random(1, 6), math.random() * 0.2 + 0.9, vol)
+				play_sound("generic1", math.random() * 0.2 + 0.9, vol)
+			end
 			return true
 		end,
 	}))

--- a/lib/overrides.lua
+++ b/lib/overrides.lua
@@ -1611,6 +1611,27 @@ function Card:get_id()
 	return vars
 end
 
+-- Hook SMODS.shatters to support editions with shatters = true (e.g. Fragile) or cards marked with will_shatter
+local smods_shatters = SMODS.shatters
+function SMODS.shatters(card)
+	if card then
+		if
+			card.edition
+			and (
+				card.edition.shatters
+				or (G.P_CENTERS and card.edition.key and G.P_CENTERS[card.edition.key] and G.P_CENTERS[card.edition.key].shatters)
+				or card.edition.cry_glass
+			)
+		then
+			return true
+		end
+		if card.shatters or card.will_shatter then
+			return true
+		end
+	end
+	return smods_shatters(card)
+end
+
 --override shatter function to adjust volume (it has been requested that at end of deck, abstract cards should shatter a bit quieter)
 function Card:shatter(volume)
 	local dissolve_time = 0.7


### PR DESCRIPTION
- Add the `not` operator to condition check for playing cards with fragile edition thus fixing the probability check logic error
- Generally improve the fragile edition code
- Remove old code that caused some buggy behavior
- Hook `SMODS.shatters` so that the cards with fragile edition will now properly shatter instead of simply dissolving