### PR TITLE
Chocolate Die grand fix

### DIFF
--- a/items/spooky.lua
+++ b/items/spooky.lua
@@ -422,26 +422,45 @@ local choco4 = { --lunar abyss
 							table.insert(faces, r)
 						end
 					end
-					local _rank = pseudorandom_element(faces, pseudoseed("cry_choco_lunar_create")).card_key
+					local _rank = pseudorandom_element(faces, "cry_choco_lunar_create").card_key
 					G.play.cards[i]:set_base(G.P_CARDS["C_" .. _rank])
 				end
 			end
 		end
 		if
 			context.post_jokers
-			and context.joker_main
+			and context.final_scoring_step
 			and not context.blueprint_card
 			and not context.retrigger_joker
 		then
 			local faces = 0
-			for i = 1, #G.play.cards do
-				if G.play.cards[i]:is_face() then
+			local cards = context.full_hand or (G.play and G.play.cards) or {}
+			for i = 1, #cards do
+				if cards[i]:is_face() then
 					faces = faces + 1
 				end
 			end
 			if faces > 1 then
-				mult = mult / faces
-				update_hand_text({ delay = 0 }, { mult = mult, chips = hand_chips })
+				G.E_MANAGER:add_event(Event({
+					func = function()
+						play_sound("multhit2", 0.7)
+						attention_text({
+							scale = 1.4,
+							text = "/" .. faces .. " Mult",
+							colour = G.C.MULT,
+							hold = 1.5,
+							align = "cm",
+							offset = { x = 0, y = -2.7 },
+							major = G.play,
+						})
+						return true
+					end,
+				}))
+				SMODS.calculate_effect({
+					x_mult = 1 / faces,
+					remove_default_message = true,
+					no_juice = true,
+				}, cards[1])
 			end
 		end
 	end,

--- a/items/spooky.lua
+++ b/items/spooky.lua
@@ -265,15 +265,17 @@ local choco3 = {
 	end,
 	finish = function(self)
 		--Reverse all potion effects
-		if G.GAME.events[self.key].potions and G.GAME.events[self.key].potions[2] then
-			G.GAME.starting_params.ante_scaling = G.GAME.starting_params.ante_scaling
-				/ (1.15 ^ G.GAME.events[self.key].potions[2])
-		end
-		if G.GAME.events[self.key].potions and G.GAME.events[self.key].potions[3] then
-			G.GAME.round_resets.hands = G.GAME.round_resets.hands + G.GAME.events[self.key].potions[3]
-			ease_hands_played(G.GAME.events[self.key].potions[3])
-			G.GAME.round_resets.discards = G.GAME.round_resets.discards + G.GAME.events[self.key].potions[3]
-			ease_discard(G.GAME.events[self.key].potions[3])
+		if G.GAME.events[self.key] and G.GAME.events[self.key].potions then
+			if G.GAME.events[self.key].potions[2] then
+				G.GAME.starting_params.ante_scaling = G.GAME.starting_params.ante_scaling
+					/ (1.15 ^ G.GAME.events[self.key].potions[2])
+			end
+			if G.GAME.events[self.key].potions[3] then
+				G.GAME.round_resets.hands = G.GAME.round_resets.hands + G.GAME.events[self.key].potions[3]
+				ease_hands_played(G.GAME.events[self.key].potions[3])
+				G.GAME.round_resets.discards = G.GAME.round_resets.discards + G.GAME.events[self.key].potions[3]
+				ease_discard(G.GAME.events[self.key].potions[3])
+			end
 		end
 		G.GAME.events[self.key] = nil
 	end,

--- a/items/spooky.lua
+++ b/items/spooky.lua
@@ -154,7 +154,7 @@ local choco_dice = {
 			if prev_ev then
 				prev_ev:finish()
 			end
-			card.ability.extra.roll = Cryptid.roll("cry_choco", 2, 10, { ignore_value = card.ability.extra.roll })
+			card.ability.extra.roll = Cryptid.roll("cry_choco", 1, 10, { ignore_value = card.ability.extra.roll })
 			local next_ev = SMODS.Events["ev_cry_choco" .. card.ability.extra.roll]
 			if next_ev then
 				next_ev:start()
@@ -182,22 +182,21 @@ local choco1 = {
 	object_type = "Event",
 	key = "choco1",
 	loc_vars = function(self, info_queue, center)
-		local _, prob_den = SMODS.get_probability_vars(self, 1, 6, "Chocolate Dice 1")
-		info_queue[#info_queue + 1] = { set = "Other", key = self.key } --todo specific_vars
+		info_queue[#info_queue + 1] = { set = "Other", key = self.key }
 		info_queue[#info_queue + 1] = { set = "Other", key = "cry_flickering_desc", specific_vars = { 5 } }
-		info_queue[#info_queue + 1] = {
-			set = "Joker",
-			key = "j_cry_ghost",
-			specific_vars = { SMODS.get_probability_vars(self, 1, 2, "Chocolate Dice 1"), prob_den },
-		}
+		if G.P_CENTERS and G.P_CENTERS.j_cry_ghost then
+			info_queue[#info_queue + 1] = G.P_CENTERS.j_cry_ghost
+		end
 	end,
 	start = function(self)
 		G.GAME.events[self.key] = true
 		local areas = { "jokers", "deck", "hand", "play", "discard" }
-		for k, v in pairs(areas) do
-			for i = 1, #G[v].cards do
-				if SMODS.pseudorandom_probability(self, "cry_choco_possession", 1, 3, "Chocolate Dice 1") then
-					SMODS.Stickers.cry_flickering:apply(G[v].cards[i], true)
+		for _, area_name in ipairs(areas) do
+			if G[area_name] and G[area_name].cards then
+				for i = 1, #G[area_name].cards do
+					if SMODS.pseudorandom_probability(self, "cry_choco_possession", 1, 3, "Chocolate Dice 1") then
+						SMODS.Stickers.cry_flickering:apply(G[area_name].cards[i], true)
+					end
 				end
 			end
 		end
@@ -1136,23 +1135,29 @@ local ghost = {
 			and not context.blueprint
 			and not context.retrigger_joker
 		then
+			local extra = card and card.ability and card.ability.extra or self.config.extra
 			if
 				SMODS.pseudorandom_probability(
 					card,
 					"cry_ghost_destroy",
 					1,
-					(card and card.ability.extra.odds or self.config.extra.odds) * card.ability.extra.destroy_rate
+					extra.destroy_rate,
+					"Ghost Destroy"
 				)
 			then
 				G.E_MANAGER:add_event(Event({
 					func = function()
 						card:start_dissolve()
-						for i = 1, #G.jokers.cards do
-							if G.jokers.cards[i].ability.cry_possessed then
-								if SMODS.is_eternal(G.jokers.cards[i]) then
-									G.jokers.cards[i].ability.cry_possessed = nil
+						for i = #G.jokers.cards, 1, -1 do
+							local j = G.jokers.cards[i]
+							if j and j.ability and j.ability.cry_possessed then
+								if SMODS.is_eternal(j) then
+									j.ability.cry_possessed = nil
+									if SMODS.Stickers and SMODS.Stickers.cry_possessed then
+										SMODS.Stickers.cry_possessed:apply(j, false)
+									end
 								else
-									G.jokers.cards[i]:start_dissolve()
+									j:start_dissolve()
 								end
 							end
 						end
@@ -1165,23 +1170,33 @@ local ghost = {
 			if
 				SMODS.pseudorandom_probability(
 					card,
-					"ghostdestroy",
+					"cry_ghost_possess",
 					1,
-					(card and card.ability.extra.odds or self.config.extra.odds) * card.ability.extra.possess_rate
+					extra.possess_rate,
+					"Ghost Possess"
 				)
 			then
 				for i = 1, #G.jokers.cards do
-					G.jokers.cards[i].ability.cry_possessed = nil
+					local j = G.jokers.cards[i]
+					if j and j.ability then
+						j.ability.cry_possessed = nil
+						if SMODS.Stickers and SMODS.Stickers.cry_possessed then
+							SMODS.Stickers.cry_possessed:apply(j, false)
+						end
+					end
 				end
 				local eligible_cards = {}
 				for i = 1, #G.jokers.cards do
-					if G.jokers.cards[i].config.center.key ~= "j_cry_ghost" then
-						table.insert(eligible_cards, i)
+					if G.jokers.cards[i] ~= card and G.jokers.cards[i].config.center.key ~= "j_cry_ghost" then
+						table.insert(eligible_cards, G.jokers.cards[i])
 					end
 				end
 				if #eligible_cards ~= 0 then
-					G.jokers.cards[pseudorandom_element(eligible_cards, pseudoseed("cry_ghost_possess_choice"))].ability.cry_possessed =
-						true
+					local target = pseudorandom_element(eligible_cards, "cry_ghost_possess_choice")
+					target.ability.cry_possessed = true
+					if SMODS.Stickers and SMODS.Stickers.cry_possessed then
+						SMODS.Stickers.cry_possessed:apply(target, true)
+					end
 				end
 				return
 			end
@@ -1189,22 +1204,15 @@ local ghost = {
 	end,
 	loc_vars = function(self, info_queue, card)
 		info_queue[#info_queue + 1] = { set = "Other", key = "cry_possessed" }
-		local num, denom = SMODS.get_probability_vars(
-			card,
-			1,
-			(card and card.ability.extra.odds or self.config.extra.odds) * card.ability.extra.destroy_rate
-		)
-		local num2, denom2 = SMODS.get_probability_vars(
-			card,
-			1,
-			(card and card.ability.extra.odds or self.config.extra.odds) * card.ability.extra.possess_rate
-		)
+		local extra = card and card.ability and card.ability.extra or self.config.extra
+		local num1, denom1 = SMODS.get_probability_vars(card, 1, extra.possess_rate, "Ghost Possess")
+		local num2, denom2 = SMODS.get_probability_vars(card, 1, extra.destroy_rate, "Ghost Destroy")
 		return {
 			vars = {
-				num2,
 				num1,
-				denom2,
+				num2,
 				denom1,
+				denom2,
 			},
 		}
 	end,
@@ -2248,7 +2256,7 @@ items = {
 	wrapped,
 	choco_dice,
 	choco_base_event,
-	--choco1,
+	choco1,
 	choco2,
 	choco3,
 	potion,
@@ -2265,8 +2273,8 @@ items = {
 	candy_basket,
 	blacklist,
 	rotten_egg,
-	--ghost,
-	--possessed,
+	ghost,
+	possessed,
 	spookydeck,
 	candy_dagger,
 	candy_cane,

--- a/items/spooky.lua
+++ b/items/spooky.lua
@@ -186,7 +186,7 @@ local choco1 = {
 	loc_vars = function(self, info_queue, center)
 		info_queue[#info_queue + 1] = { set = "Other", key = self.key }
 		info_queue[#info_queue + 1] = { set = "Other", key = "cry_flickering_desc", specific_vars = { 5 } }
-		if G.P_CENTERS and G.P_CENTERS.j_cry_ghost then
+		if G.P_CENTERS.j_cry_ghost then
 			info_queue[#info_queue + 1] = G.P_CENTERS.j_cry_ghost
 		end
 	end,
@@ -435,7 +435,7 @@ local choco4 = { --lunar abyss
 			and not context.retrigger_joker
 		then
 			local faces = 0
-			local cards = context.full_hand or (G.play and G.play.cards) or {}
+			local cards = context.full_hand or G.play.cards or {}
 			for i = 1, #cards do
 				if cards[i]:is_face() then
 					faces = faces + 1

--- a/items/spooky.lua
+++ b/items/spooky.lua
@@ -457,16 +457,7 @@ local choco5 = { --bloodsucker
 		then
 			if context.destroying_card:is_suit("Hearts") or context.destroying_card:is_suit("Diamonds") then
 				if SMODS.pseudorandom_probability(self, "cry_choco_blood", 1, 3, "Chocolate Dice 5") then
-					context.destroying_card.will_shatter = true
-					local destroying_card = context.destroying_card
-					G.E_MANAGER:add_event(Event({
-						func = function()
-							if destroying_card then
-								destroying_card:start_dissolve()
-							end
-							return true
-						end,
-					}))
+					return { remove = not SMODS.is_eternal(context.destroying_card) }
 				end
 			end
 		end

--- a/items/spooky.lua
+++ b/items/spooky.lua
@@ -129,15 +129,15 @@ local choco_dice = {
 	immutable = true,
 	no_dbl = true,
 	loc_vars = function(self, info_queue, center)
-		if not center then --tooltip
-		else
+		if center and center.ability and center.ability.extra and center.ability.extra.roll and center.ability.extra.roll > 0 then
 			local ev = SMODS.Events["ev_cry_choco" .. center.ability.extra.roll]
 			if ev and ev.loc_vars then
 				ev:loc_vars(info_queue, center)
 			end
 		end
+		local roll_val = (center and center.ability and center.ability.extra and center.ability.extra.roll) or 0
 		return {
-			vars = { not center and "None" or center.ability.extra.roll == 0 and "None" or center.ability.extra.roll },
+			vars = { roll_val == 0 and "None" or roll_val },
 		}
 	end,
 	calculate = function(self, card, context)
@@ -174,10 +174,12 @@ local choco_dice = {
 		end
 	end,
 }
+--[[
 local choco_base_event = {
 	object_type = "Event",
 	key = "choco0",
 }
+]]
 local choco1 = {
 	object_type = "Event",
 	key = "choco1",
@@ -2255,7 +2257,7 @@ items = {
 	cotton_candy,
 	wrapped,
 	choco_dice,
-	choco_base_event,
+	--choco_base_event,
 	choco1,
 	choco2,
 	choco3,

--- a/items/spooky.lua
+++ b/items/spooky.lua
@@ -131,7 +131,10 @@ local choco_dice = {
 	loc_vars = function(self, info_queue, center)
 		if not center then --tooltip
 		else
-			SMODS.Events["ev_cry_choco" .. center.ability.extra.roll]:loc_vars(info_queue, center)
+			local ev = SMODS.Events["ev_cry_choco" .. center.ability.extra.roll]
+			if ev and ev.loc_vars then
+				ev:loc_vars(info_queue, center)
+			end
 		end
 		return {
 			vars = { not center and "None" or center.ability.extra.roll == 0 and "None" or center.ability.extra.roll },
@@ -147,9 +150,15 @@ local choco_dice = {
 			and Cryptid.is_boss_blind(G.GAME.blind)
 		then
 			--todo: check if duplicates of event are already started/finished
-			SMODS.Events["ev_cry_choco" .. card.ability.extra.roll]:finish()
+			local prev_ev = SMODS.Events["ev_cry_choco" .. card.ability.extra.roll]
+			if prev_ev then
+				prev_ev:finish()
+			end
 			card.ability.extra.roll = Cryptid.roll("cry_choco", 2, 10, { ignore_value = card.ability.extra.roll })
-			SMODS.Events["ev_cry_choco" .. card.ability.extra.roll]:start()
+			local next_ev = SMODS.Events["ev_cry_choco" .. card.ability.extra.roll]
+			if next_ev then
+				next_ev:start()
+			end
 			return {
 				message = tostring(card.ability.extra.roll),
 				colour = G.C.GREEN,
@@ -158,7 +167,10 @@ local choco_dice = {
 	end,
 	remove_from_deck = function(self, card, from_debuff)
 		if not from_debuff then
-			SMODS.Events["ev_cry_choco" .. card.ability.extra.roll]:finish()
+			local ev = SMODS.Events["ev_cry_choco" .. card.ability.extra.roll]
+			if ev then
+				ev:finish()
+			end
 		end
 	end,
 }
@@ -220,6 +232,14 @@ local choco2 = {
 				return
 			end
 			return gfcr(e)
+		end
+		--prevent skipping blind
+		local gfsb = G.FUNCS.skip_blind
+		G.FUNCS.skip_blind = function(e)
+			if G.GAME.events and G.GAME.events.ev_cry_choco2 then
+				return
+			end
+			return gfsb(e)
 		end
 	end,
 }

--- a/items/spooky.lua
+++ b/items/spooky.lua
@@ -200,7 +200,7 @@ local choco2 = {
 	key = "choco2",
 	--everything here is done with lovely patches or hooks, search for ev_cry_choco2
 	calculate = function(self, context)
-		if context.cash_out then
+		if context.post_jokers and context.cash_out then
 			G.GAME.current_round.rerolled = false
 		end
 	end,
@@ -467,30 +467,13 @@ local choco6 = { --please take one
 	object_type = "Event",
 	key = "choco6",
 	calculate = function(self, context)
-		if context.pre_cash then
+		if context.post_jokers and context.start_shop then
 			G.E_MANAGER:add_event(Event({
 				func = function()
-					local key = get_pack("cry_take_one").key
-					local card = Card(
-						G.play.T.x + G.play.T.w / 2 - G.CARD_W * 1.27 / 2,
-						G.play.T.y + G.play.T.h / 2 - G.CARD_H * 1.27 / 2,
-						G.CARD_W * 1.27,
-						G.CARD_H * 1.27,
-						G.P_CARDS.empty,
-						G.P_CENTERS[key],
-						{ bypass_discovery_center = true, bypass_discovery_ui = true }
-					)
-					card.cost = 0
-					card.from_tag = true
-					G.FUNCS.use_card({ config = { ref_table = card } })
-					card:start_materialize()
-					pack_opened = true
+					Cryptid.open_booster()
 					return true
 				end,
 			}))
-		end
-		if context.setting_blind then
-			pack_opened = nil
 		end
 	end,
 }
@@ -509,7 +492,7 @@ local choco7 = {
 		G.jokers:emplace(card)
 	end,
 	calculate = function(self, context)
-		if context.start_shop then
+		if context.post_jokers and context.start_shop then
 			local tag = Tag("tag_cry_rework")
 			if not tag.ability then
 				tag.ability = {}
@@ -542,7 +525,7 @@ local choco8 = {
 	object_type = "Event",
 	key = "choco8",
 	calculate = function(self, context)
-		if context.cash_out then
+		if context.post_jokers and context.cash_out then
 			for i = 1, G.GAME.current_round.hands_left do
 				local card = create_card("Joker", G.jokers, nil, "cry_candy", nil, nil, nil, "cry_choco8")
 				card:add_to_deck()

--- a/items/spooky.lua
+++ b/items/spooky.lua
@@ -129,7 +129,13 @@ local choco_dice = {
 	immutable = true,
 	no_dbl = true,
 	loc_vars = function(self, info_queue, center)
-		if center and center.ability and center.ability.extra and center.ability.extra.roll and center.ability.extra.roll > 0 then
+		if
+			center
+			and center.ability
+			and center.ability.extra
+			and center.ability.extra.roll
+			and center.ability.extra.roll > 0
+		then
 			local ev = SMODS.Events["ev_cry_choco" .. center.ability.extra.roll]
 			if ev and ev.loc_vars then
 				ev:loc_vars(info_queue, center)
@@ -1138,15 +1144,7 @@ local ghost = {
 			and not context.retrigger_joker
 		then
 			local extra = card and card.ability and card.ability.extra or self.config.extra
-			if
-				SMODS.pseudorandom_probability(
-					card,
-					"cry_ghost_destroy",
-					1,
-					extra.destroy_rate,
-					"Ghost Destroy"
-				)
-			then
+			if SMODS.pseudorandom_probability(card, "cry_ghost_destroy", 1, extra.destroy_rate, "Ghost Destroy") then
 				G.E_MANAGER:add_event(Event({
 					func = function()
 						card:start_dissolve()
@@ -1169,15 +1167,7 @@ local ghost = {
 				return
 			end
 			--todo: let multiple ghosts possess multiple jokers
-			if
-				SMODS.pseudorandom_probability(
-					card,
-					"cry_ghost_possess",
-					1,
-					extra.possess_rate,
-					"Ghost Possess"
-				)
-			then
+			if SMODS.pseudorandom_probability(card, "cry_ghost_possess", 1, extra.possess_rate, "Ghost Possess") then
 				for i = 1, #G.jokers.cards do
 					local j = G.jokers.cards[i]
 					if j and j.ability then

--- a/items/spooky.lua
+++ b/items/spooky.lua
@@ -254,7 +254,7 @@ local choco3 = {
 		for i = 1, 3 do
 			local card = create_card("Unique", G.consumeables, nil, nil, nil, nil, "c_cry_potion")
 			card:add_to_deck()
-			card.ability.random_event = pseudorandom(pseudoseed("cry_choco_witch"), 1, num_potions)
+			card.ability.random_event = pseudorandom("cry_choco_witch", 1, num_potions)
 			G.consumeables:emplace(card)
 		end
 	end,
@@ -374,10 +374,12 @@ local potion = {
 			)
 			update_hand_text({ delay = 0 }, { mult = "-", StatusText = true })
 			update_hand_text({ delay = 0 }, { chips = "-", StatusText = true })
-			update_hand_text({ sound = "button", volume = 0.7, pitch = 0.9, delay = 0 }, { level = "+1" })
+			update_hand_text({ sound = "button", volume = 0.7, pitch = 0.9, delay = 0 }, { level = "-1" })
 			delay(1.3)
 			for k, v in pairs(G.GAME.hands) do
-				level_up_hand(card, k, true, -1)
+				if v.level > 1 then
+					level_up_hand(card, k, true, -1)
+				end
 			end
 			update_hand_text(
 				{ sound = "button", volume = 0.7, pitch = 1.1, delay = 0 },

--- a/lib/calculate.lua
+++ b/lib/calculate.lua
@@ -49,10 +49,20 @@ local cj = Card.calculate_joker
 
 local smcc = SMODS.calculate_context
 function SMODS.calculate_context(context, return_table)
+	local ret = {}
 	for k, v in pairs(SMODS.Events) do
 		if G.GAME.events and G.GAME.events[k] then
 			context.pre_jokers = true
-			v:calculate(context)
+			local res = v:calculate(context)
+			if res and type(res) == "table" then
+				if return_table then
+					return_table[#return_table + 1] = res
+				else
+					for rk, rv in pairs(res) do
+						ret[rk] = rv
+					end
+				end
+			end
 			context.pre_jokers = nil
 		end
 	end
@@ -94,11 +104,25 @@ function SMODS.calculate_context(context, return_table)
 			SMODS.trigger_effects(effects, _card)
 		end
 	end
-	local ret = smcc(context, return_table)
+	local smcc_ret = smcc(context, return_table)
+	if smcc_ret and type(smcc_ret) == "table" then
+		for rk, rv in pairs(smcc_ret) do
+			ret[rk] = rv
+		end
+	end
 	for k, v in pairs(SMODS.Events) do
 		if G.GAME.events and G.GAME.events[k] then
 			context.post_jokers = true
-			v:calculate(context)
+			local res = v:calculate(context)
+			if res and type(res) == "table" then
+				if return_table then
+					return_table[#return_table + 1] = res
+				else
+					for rk, rv in pairs(res) do
+						ret[rk] = rv
+					end
+				end
+			end
 			context.post_jokers = nil
 		end
 	end

--- a/lib/calculate.lua
+++ b/lib/calculate.lua
@@ -162,7 +162,7 @@ function Card:calculate_joker(context)
 	--local orig_ability = copy_table(active_side.ability)
 	local in_context_scaling = false
 	local callback = context.callback
-	if active_side.ability.cry_possessed then
+	if active_side.ability and active_side.ability.cry_possessed then
 		if
 			not (
 				(context.individual and not context.repetition)
@@ -175,7 +175,7 @@ function Card:calculate_joker(context)
 		context.callback = nil
 	end
 	local ret, trig = cj(active_side, context)
-	if active_side.ability.cry_possessed and ret then
+	if active_side.ability and active_side.ability.cry_possessed and ret then
 		if ret.mult_mod then
 			ret.mult_mod = ret.mult_mod * -1
 		end
@@ -229,7 +229,9 @@ function Card:calculate_joker(context)
 				ret.message = ret.message .. "?"
 			end
 		end
-		callback(context.blueprint_card or self, ret, context.retrigger_joker)
+		if callback then
+			callback(context.blueprint_card or self, ret, context.retrigger_joker)
+		end
 	end
 	if not context.blueprint and (active_side.ability.set == "Joker") and not active_side.debuff then
 		if ret or trig then

--- a/lib/misc.lua
+++ b/lib/misc.lua
@@ -43,6 +43,27 @@ function Cryptid.has_ongoing_run()
 	return (G.STAGE == G.STAGES.RUN) or not not love.filesystem.getInfo(G.SETTINGS.profile .. "/" .. "save.jkr")
 end
 
+function Cryptid.open_booster(pack_key)
+	local key = pack_key or get_pack("cry_take_one").key
+	local card = Card(
+		G.play.T.x + G.play.T.w / 2 - G.CARD_W * 1.27 / 2,
+		G.play.T.y + G.play.T.h / 2 - G.CARD_H * 1.27 / 2,
+		G.CARD_W * 1.27,
+		G.CARD_H * 1.27,
+		G.P_CARDS.empty,
+		G.P_CENTERS[key],
+		{ bypass_discovery_center = true, bypass_discovery_ui = true }
+	)
+	card.cost = 0
+	card.from_tag = true
+	if G.shop and not G.shop.alignment.offset.py then
+		G.shop.alignment.offset.py = -5.3
+	end
+	G.FUNCS.use_card({ config = { ref_table = card } })
+	card:start_materialize()
+	return card
+end
+
 -- More advanced version of find joker for things that need to find very specific things
 function Cryptid.advanced_find_joker(name, rarity, edition, ability, non_debuff, area)
 	local jokers = {}

--- a/lovely/challenges.toml
+++ b/lovely/challenges.toml
@@ -3,22 +3,22 @@ version = "1.0.0"
 dump_lua = true
 priority = -1
 
-# Rush Hour - remove tags
+# Rush Hour / Haunted House - remove tags
 [[patches]]
 [patches.pattern]
 target = "functions/UI_definitions.lua"
 pattern = "if type == 'Small' then"
 position = "at"
-payload = "if type == 'Small' and not G.GAME.modifiers.cry_no_tags then"
+payload = "if type == 'Small' and not G.GAME.modifiers.cry_no_tags and not (G.GAME.events and G.GAME.events.ev_cry_choco2) then"
 match_indent = true
 
-# Rush Hour - remove tags
+# Rush Hour / Haunted House - remove tags
 [[patches]]
 [patches.pattern]
 target = "functions/UI_definitions.lua"
 pattern = "elseif type == 'Big' then"
 position = "at"
-payload = "elseif type == 'Big' and not G.GAME.modifiers.cry_no_tags then"
+payload = "elseif type == 'Big' and not G.GAME.modifiers.cry_no_tags and not (G.GAME.events and G.GAME.events.ev_cry_choco2) then"
 match_indent = true
 
 # Rush Hour - remove tags

--- a/lovely/spooky.toml
+++ b/lovely/spooky.toml
@@ -3,15 +3,6 @@ version = "1.0.0"
 dump_lua = true
 priority = 10
 
-# Haunted House - useless skips
-[[patches]]
-[patches.regex]
-target = "functions/button_callbacks.lua"
-pattern = 'if _tag then'
-position = 'at'
-line_prepend = '$indent'
-payload = '''if _tag and not G.GAME.events.ev_cry_choco2 then'''
-
 
 # Revered Antique - create legendary
 [[patches]]

--- a/lovely/spooky.toml
+++ b/lovely/spooky.toml
@@ -12,14 +12,6 @@ position = 'at'
 line_prepend = '$indent'
 payload = '''if _tag and not G.GAME.events.ev_cry_choco2 then'''
 
-# Please Take One jank
-[[patches]]
-[patches.pattern]
-target = "game.lua"
-pattern = '''ease_background_colour_blind(G.STATES.ROUND_EVAL)'''
-position = "after"
-payload = '''if G.GAME.events.ev_cry_choco6 and G.round_eval then return true end'''
-match_indent = true
 
 # Revered Antique - create legendary
 [[patches]]


### PR DESCRIPTION
## Summary of Changes

This PR comprehensively fixes, restores, and polishes **Chocolate Die**, its events, and associated items/stickers.

---

### Chocolate Die (`j_cry_chocolate_dice`)
- **Restored Roll Range**: Restored roll range from `[2, 10]` to `[1, 10]` to re-enable Event 1.
- **Nil Safety**: Added safety guards when initializing, starting, and finishing events on round transitions.
- **Event List Tooltip Cleanup (`choco0`)**: Temporarily commented out the unfinished `choco0` ("Possible Events") tooltip box for now (due to Balatro engine limitations with interactive sub-tooltips on hover). Preserved the code in comments so a custom UI can re-enable it in the future.

---

### Event 1: Ghostly Possession, Ghost Joker (`j_cry_ghost`), & Possessed Sticker (`cry_possessed`)
- **Re-enabled**: Uncommented and re-enabled Event 1, Ghost Joker, and the Possessed sticker.
- **Ghost Tooltip & Probability Crash**: Fixed variable order and missing probability parameters in `j_cry_ghost:loc_vars`.
- **Dissolution Loop Crash**: Iterated backwards (`for i = #G.jokers.cards, 1, -1 do`) when Ghost self-destructs with possessed Jokers to prevent table indexing crashes.
- **Possessed Sticker Scoring Crash**: Fixed `Card:calculate_joker` where possessed cards called `context.callback` without checking if a callback was provided.
- **Sticker Lifecycle**: Ensured `cry_possessed` sticker is properly applied and stripped during Ghost triggers.
- **Event 1 Tooltip Crash**: Fixed `choco1:loc_vars` crash by referencing registered center `G.P_CENTERS.j_cry_ghost`.

---

### Event 2: Haunted House
- **Blind Skipping**: Fixed blind skip prevention to properly disable skip buttons during Small and Big Blinds.

---

### Event 3: Witch's Brews
- **Potion RNG & Safety**: Fixed potion generation RNG and ensured hand level reduction cannot drop hand levels below level 1.
- **Potion Tooltips**: Fixed `c_cry_potion` info tooltip references.

---

### Event 4: Lunar Abyss
- **Scoring Timing**: Moved Mult division to `context.final_scoring_step` so Mult divides by the number of played face cards right after Jokers calculate.
- **UI Message**: Centered the division announcement banner over played cards (`G.play`).
- **Face Card RNG**: Fixed RNG key for Club face card conversions.

---

### Event 5: Bloodsucker
- **Card Destruction**: Switched to standard SMODS destruction return (`{ remove = not SMODS.is_eternal(context.destroying_card) }`) instead of manual dissolution event scheduling.

---

### Event 6: Please Take One
- **Booster Opening**: Added `Cryptid.open_booster()` helper and fixed trigger context (`context.post_jokers and context.start_shop`) so the free booster pack opens cleanly at the start of the shop without UI conflicts or double activations.

---

### Event 7: Festive Atmosphere
- **Trigger Timing**: Fixed shop trigger to `context.post_jokers and context.start_shop` to prevent duplicate shop triggers.

---

### Event 8: Candy Rain
- **Trigger Timing**: Fixed cash-out trigger to `context.post_jokers and context.cash_out` to prevent duplicate candy generation.

---

### General Improvements & Cleanup
- Removed obsolete lovely patches from `spooky.toml`.
- Added nil guards and cleanup across event handlers.
