### PR TITLE
Add custom descriptions to antimatter deck select screen

### DIFF
--- a/lib/content.lua
+++ b/lib/content.lua
@@ -1368,7 +1368,7 @@ SMODS.RunSelectPage({
 	create_selection_card = function(self, card_key, card_number, area)
 		local card = Card(area.T.x, area.T.y, G.CARD_W, G.CARD_H, nil, G.P_CENTERS[card_key] or G.P_CENTERS.b_red)
 		local unlocked = Cryptid.antimatter_compat(card_key)
-		card.cry_antimatter_card = true --figure out how to make this actually display a different description
+		card.cry_antimatter_card = true
 		card.cry_antimatter_locked = not unlocked
 		card.sprite_facing = "back"
 		card.facing = "back"

--- a/lib/ui.lua
+++ b/lib/ui.lua
@@ -362,8 +362,43 @@ function Card:hover()
 	if self.children.h_popup then
 		return
 	end
+	local is_antimatter = self.cry_antimatter_card
+	local has_antimatter_loc_vars = is_antimatter and self.config.center.cry_antimatter_loc_vars
+	local orig_loc_vars = nil
+	if is_antimatter then
+		Cryptid.in_antimatter_hover = self
+		if has_antimatter_loc_vars then
+			orig_loc_vars = self.config.center.loc_vars
+			self.config.center.loc_vars = self.config.center.cry_antimatter_loc_vars
+		end
+	end
 	ch(self)
+	if is_antimatter then
+		if has_antimatter_loc_vars then
+			self.config.center.loc_vars = orig_loc_vars
+		end
+		Cryptid.in_antimatter_hover = nil
+	end
 end
+
+local loc_ref = localize
+function localize(args, misc_cat)
+	if Cryptid.in_antimatter_hover and type(args) == "table" and args.type == "descriptions" and args.set == "Back" then
+		if G.localization.descriptions.Back[args.key .. "_antimatter"] then
+			args.key = args.key .. "_antimatter"
+		end
+	end
+	return loc_ref(args, misc_cat)
+end
+
+local orig_grab_tooltips = SMODS.RunSelect.Functions.grab_tooltips
+function SMODS.RunSelect.Functions.grab_tooltips(set, key)
+	if Cryptid.in_antimatter_hover and set == "Back" and G.localization.descriptions.Back[key .. "_antimatter"] then
+		key = key .. "_antimatter"
+	end
+	return orig_grab_tooltips(set, key)
+end
+
 
 local G_UIDEF_use_and_sell_buttons_ref = G.UIDEF.use_and_sell_buttons
 function G.UIDEF.use_and_sell_buttons(card)

--- a/lib/ui.lua
+++ b/lib/ui.lua
@@ -399,7 +399,6 @@ function SMODS.RunSelect.Functions.grab_tooltips(set, key)
 	return orig_grab_tooltips(set, key)
 end
 
-
 local G_UIDEF_use_and_sell_buttons_ref = G.UIDEF.use_and_sell_buttons
 function G.UIDEF.use_and_sell_buttons(card)
 	local abc = G_UIDEF_use_and_sell_buttons_ref(card)

--- a/localization/de.lua
+++ b/localization/de.lua
@@ -274,6 +274,86 @@ return {
 					"{C:attention}2 Legendäre Joker",
 				},
 			},
+
+			b_black_antimatter = {
+				name = "Schwarzes Deck",
+				text = {
+					"{C:attention}+#1#{} Joker-Slot",
+				},
+			},
+			b_green_antimatter = {
+				name = "Grünes Deck",
+				text = {
+					"Zum Ende jeder Runde:",
+					"{C:money}#1# ${s:0.85} pro verbleibender {C:blue}Hand",
+					"{C:money}#1# ${s:0.85} pro verbleibenden {C:blue}Abwurf",
+				},
+			},
+			b_nebula_antimatter = {
+				name = "Nebula-Deck",
+				text = {
+					"Beginne den Durchlauf mit dem",
+					"{C:planet,T:v_telescope}#1#{}-Gutschein",
+				},
+			},
+			b_painted_antimatter = {
+				name = "Farbiges Deck",
+				text = {
+					"{C:attention}+#1#{} Handgröße",
+				},
+			},
+			b_plasma_antimatter = {
+				name = "Plasma-Deck",
+				text = {
+					"{C:blue}Chips{} und",
+					"{C:red}Mult{} werden ausgeglichen, wenn",
+					"die Punktzahl für die gespielte Hand berechnet wird",
+				},
+			},
+			b_cry_beta_antimatter = {
+				name = "Nostalgisches Deck",
+				text = {
+					"{C:attention}Joker{} und {C:attention}Verbrauchsgegenstände{}",
+					"Slots sind {C:attention}zusammengefasst{}",
+				},
+			},
+			b_cry_conveyor_antimatter = {
+				name = "Fließband-Deck",
+				text = {
+					"Am Anfang der Runde,",
+					"{C:attention}dupliziere{} den Joker ganz rechts",
+				},
+			},
+			b_cry_critical_antimatter = {
+				name = "Kritisches Deck",
+				text = {
+					"Nach jeder gespielten Hand,",
+					"Chance von {C:green}#1# zu #2#{} für {X:dark_edition,C:white} ^2 {} Mult",
+				},
+			},
+			b_cry_encoded_antimatter = {
+				name = "Verschlüsseltes Deck",
+				text = {
+					"Starte mit einem {C:cry_code,T:j_cry_CodeJoker}Code Joker{}",
+					"und einem {C:cry_code,T:j_cry_copypaste}Copy/Paste{}",
+				},
+			},
+			b_cry_spooky_antimatter = {
+				name = "Gruseliges Deck",
+				text = {
+					"Starte mit einem {C:attention,T:j_cry_chocolate_dice}Schokoladenwürfel",
+					"Nach jeder {C:attention}Ante{}, erstelle eine",
+					"{C:cry_candy}Süßigkeit{} oder einen {X:cry_cursed,C:white}Verfluchten{} Joker",
+				},
+			},
+			b_cry_wormhole_antimatter = {
+				name = "Wurmloch Deck",
+				text = {
+					"Beginne mit einem {C:cry_exotic}Exotischen{C:attention} Joker",
+					"Joker sind {C:attention}20X{} wahrscheinlicher",
+					"{C:dark_edition}Negativ{} zu sein",
+				},
+			},
 		},
 		Blind = {
 			bl_cry_box = {

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -320,6 +320,85 @@ return {
 					"Obtain an {C:cry_exotic}Exotic{C:attention} Joker",
 				},
 			},
+			b_black_antimatter = {
+				name = "Black Deck",
+				text = {
+					"{C:attention}+#1#{} Joker slot",
+				},
+			},
+			b_green_antimatter = {
+				name = "Green Deck",
+				text = {
+					"At end of each Round:",
+					"{C:money}$#1#{s:0.85} per remaining {C:blue}Hand",
+					"{C:money}$#2#{s:0.85} per remaining {C:red}Discard",
+				},
+			},
+			b_nebula_antimatter = {
+				name = "Nebula Deck",
+				text = {
+					"Start run with the",
+					"{C:planet,T:v_telescope}#1#{} voucher",
+				},
+			},
+			b_painted_antimatter = {
+				name = "Painted Deck",
+				text = {
+					"{C:attention}+#1#{} hand size",
+				},
+			},
+			b_plasma_antimatter = {
+				name = "Plasma Deck",
+				text = {
+					"Balance {C:blue}Chips{} and",
+					"{C:red}Mult{} when calculating",
+					"score for played hand",
+				},
+			},
+			b_cry_beta_antimatter = {
+				name = "Nostalgic Deck",
+				text = {
+					"{C:attention}Joker{} and {C:attention}Consumable{}",
+					"slots are {C:attention}combined",
+				},
+			},
+			b_cry_conveyor_antimatter = {
+				name = "Conveyor Deck",
+				text = {
+					"At start of round,",
+					"{C:attention}duplicate{} rightmost Joker",
+				},
+			},
+			b_cry_critical_antimatter = {
+				name = "Critical Deck",
+				text = {
+					"After each hand played,",
+					"{C:green}#1# in #2#{} chance for {X:talisman_emult,C:white} ^2 {} Mult",
+				},
+			},
+			b_cry_encoded_antimatter = {
+				name = "Encoded Deck",
+				text = {
+					"Start with a {C:cry_code,T:j_cry_CodeJoker}Code Joker{}",
+					"and a {C:cry_code,T:j_cry_copypaste}Copy/Paste{}",
+				},
+			},
+			b_cry_spooky_antimatter = {
+				name = "Spooky Deck",
+				text = {
+					"Start with a {C:attention,T:j_cry_chocolate_dice}Chocolate Die",
+					"After each {C:attention}Ante{}, create a",
+					"{C:cry_candy}Candy{} or {X:cry_cursed,C:white}Cursed{} Joker",
+				},
+			},
+			b_cry_wormhole_antimatter = {
+				name = "Wormhole Deck",
+				text = {
+					"Start with an {C:cry_exotic}Exotic{C:attention} Joker",
+					"Jokers are {C:attention}20X{} more",
+					"likely to be {C:dark_edition}Negative",
+				},
+			},
 			b_cry_legendary = {
 				name = "Legendary Deck",
 				text = {

--- a/localization/es_419.lua
+++ b/localization/es_419.lua
@@ -141,6 +141,86 @@ return {
 					"{C:inactive}(debe haber espacio){}",
 				},
 			},
+
+			b_black_antimatter = {
+				name = "Baraja negra",
+				text = {
+					"{C:attention}+#1#{} ranura(s) de comodín",
+				},
+			},
+			b_green_antimatter = {
+				name = "Baraja verde",
+				text = {
+					"Al final de cada ronda:",
+					"{C:money}#1# ${s:0.85} por {C:blue}mano restante",
+					"{C:money}#2# ${s:0.85} por {C:red}descarte restante",
+				},
+			},
+			b_nebula_antimatter = {
+				name = "Baraja nébula",
+				text = {
+					"Comienza la partida",
+					"con el vale {C:planet,T:v_telescope}#1#{}",
+				},
+			},
+			b_painted_antimatter = {
+				name = "Baraja pintada",
+				text = {
+					"{C:attention}+#1#{} tamaño de mano",
+				},
+			},
+			b_plasma_antimatter = {
+				name = "Baraja plasmática",
+				text = {
+					"Equilibra las {C:blue}fichas{} y",
+					"el {C:red}multi{} cuando calcula",
+					"los puntos de cada mano jugada",
+				},
+			},
+			b_cry_beta_antimatter = {
+				name = "Baraja nostálgica",
+				text = {
+					"Las ranuras de {C:attention}comodín{} y",
+					"{C:attention}consumibles{} se {C:attention}combinan",
+				},
+			},
+			b_cry_conveyor_antimatter = {
+				name = "Baraja transportadora",
+				text = {
+					"Al principio de la runda,",
+					"{C:attention}duplica{} el comodín del extremo derecho",
+				},
+			},
+			b_cry_critical_antimatter = {
+				name = "Baraja crítica",
+				text = {
+					"Después de cada mano jugada,",
+					"{C:green}#1# en #2#{} probabilidades para {X:dark_edition,C:white} ^2 {} multi",
+				},
+			},
+			b_cry_encoded_antimatter = {
+				name = "Baraja codificada",
+				text = {
+					"Comienza con un {C:cry_code,T:j_cry_CodeJoker}Comodín de código{}",
+					"y {C:cry_code,T:j_cry_copypaste}Copiar y pegar{}",
+				},
+			},
+			b_cry_spooky_antimatter = {
+				name = "Baraja espeluznante",
+				text = {
+					"Comienza con un {C:attention,T:j_cry_chocolate_dice}Dado de chocolate",
+					"Después de cada {C:attention}apuesta{}, crea un comodín",
+					"de {C:cry_candy}dulce{} o {X:cry_cursed,C:white}maldito{}",
+				},
+			},
+			b_cry_wormhole_antimatter = {
+				name = "Baraja de agujero de gusano",
+				text = {
+					"Comienza con un comodín {C:cry_exotic}exótico{C:attention}",
+					"Los comodines son {C:attention}20X{} más",
+					"probables de ser {C:dark_edition}Negativos",
+				},
+			},
 		},
 		Blind = {
 			bl_cry_box = {

--- a/localization/es_ES.lua
+++ b/localization/es_ES.lua
@@ -193,6 +193,86 @@ return {
 					"{C:inactive}(debe haber espacio){}",
 				},
 			},
+
+			b_black_antimatter = {
+				name = "Baraja negra",
+				text = {
+					"{C:attention}+#1#{} ranura(s) de comodín",
+				},
+			},
+			b_green_antimatter = {
+				name = "Baraja verde",
+				text = {
+					"Al final de cada ronda:",
+					"{C:money}$#1#{s:0.85} por {C:blue}mano restante",
+					"{C:money}$#2#{s:0.85} por {C:red}descarte restante",
+				},
+			},
+			b_nebula_antimatter = {
+				name = "Baraja nébula",
+				text = {
+					"Comienza la partida",
+					"con el vale {C:planet,T:v_telescope}#1#{}",
+				},
+			},
+			b_painted_antimatter = {
+				name = "Baraja pintada",
+				text = {
+					"{C:attention}+#1#{} tamaño de mano",
+				},
+			},
+			b_plasma_antimatter = {
+				name = "Baraja plasmática",
+				text = {
+					"Equilibra las {C:blue}fichas{} y",
+					"el {C:red}multi{} cuando calcula",
+					"los puntos de cada mano jugada",
+				},
+			},
+			b_cry_beta_antimatter = {
+				name = "Baraja nostálgica",
+				text = {
+					"Las ranuras de {C:attention}comodín{} y",
+					"{C:attention}consumibles{} se {C:attention}combinan",
+				},
+			},
+			b_cry_conveyor_antimatter = {
+				name = "Baraja transportadora",
+				text = {
+					"Al principio de la runda,",
+					"{C:attention}duplica{} el comodín del extremo derecho",
+				},
+			},
+			b_cry_critical_antimatter = {
+				name = "Baraja crítica",
+				text = {
+					"Después de cada mano jugada,",
+					"{C:green}#1# en #2#{} probabilidades para {X:dark_edition,C:white} ^2 {} multi",
+				},
+			},
+			b_cry_encoded_antimatter = {
+				name = "Baraja codificada",
+				text = {
+					"Comienza con un {C:cry_code,T:j_cry_CodeJoker}Comodín de código{}",
+					"y {C:cry_code,T:j_cry_copypaste}Copiar y pegar{}",
+				},
+			},
+			b_cry_spooky_antimatter = {
+				name = "Baraja espeluznante",
+				text = {
+					"Comienza con un {C:attention,T:j_cry_chocolate_dice}Dado de chocolate",
+					"Después de cada {C:attention}apuesta{}, crea un comodín",
+					"de {C:cry_candy}dulce{} o {X:cry_cursed,C:white}maldito{}",
+				},
+			},
+			b_cry_wormhole_antimatter = {
+				name = "Baraja de agujero de gusano",
+				text = {
+					"Comienza con un comodín {C:cry_exotic}exótico{C:attention}",
+					"Los comodines son {C:attention}20X{} más",
+					"probables de ser {C:dark_edition}Negativos",
+				},
+			},
 		},
 		Blind = {
 			bl_cry_box = {

--- a/localization/fr.lua
+++ b/localization/fr.lua
@@ -294,6 +294,86 @@ return {
 					"en même temps",
 				},
 			},
+
+			b_black_antimatter = {
+				name = "Jeu noir",
+				text = {
+					"{C:attention}+#1#{} emplacement de Joker",
+				},
+			},
+			b_green_antimatter = {
+				name = "Jeu vert",
+				text = {
+					"À la fin de la manche :",
+					"{C:money}#1# ${s:0.85} par {C:blue}main restante",
+					"{C:money}#2# ${s:0.85} par {C:red}défausse restante",
+				},
+			},
+			b_nebula_antimatter = {
+				name = "Jeu nébuleux",
+				text = {
+					"Commencez la partie avec le",
+					"coupon {C:planet,T:v_telescope}#1#{}",
+				},
+			},
+			b_painted_antimatter = {
+				name = "Jeu peint",
+				text = {
+					"{C:attention}+#1#{} taille de main",
+				},
+			},
+			b_plasma_antimatter = {
+				name = "Jeu plasmique",
+				text = {
+					"Équilibrez les {C:blue}jetons{} et",
+					"le {C:red}Multi{} lorsque vous calculez",
+					"le score de la main jouée",
+				},
+			},
+			b_cry_beta_antimatter = {
+				name = "Jeu Nostalgique",
+				text = {
+					"Les emplacements de {C:attention}Jokers{}",
+					"et de {C:attention}Consommables{} sont {C:attention}combinés{}",
+				},
+			},
+			b_cry_conveyor_antimatter = {
+				name = "Jeu Convoyeur",
+				text = {
+					"Au début de la manche,",
+					"{C:attention}duplique{} le Joker le plus à droite",
+				},
+			},
+			b_cry_critical_antimatter = {
+				name = "Jeu Critique",
+				text = {
+					"Après chaque main jouée,",
+					"{C:green}#1# chance sur #2#{} d'obtenir {X:dark_edition,C:white} ^2 {} Multi",
+				},
+			},
+			b_cry_encoded_antimatter = {
+				name = "Jeu Encodé",
+				text = {
+					"Démarre avec un {C:cry_code,T:j_cry_CodeJoker}Joker de Code{}",
+					"et un {C:cry_code,T:j_cry_copypaste}Copier/Coller{}",
+				},
+			},
+			b_cry_spooky_antimatter = {
+				name = "Jeu fantôme",
+				text = {
+					"Démarre avec un {C:attention,T:j_cry_chocolate_dice}Dé en chocolat",
+					"Après chaque {C:attention}Mise{}, crée un Joker",
+					"{C:cry_candy}Bonbon{} ou {X:cry_cursed,C:white}Maudit{}",
+				},
+			},
+			b_cry_wormhole_antimatter = {
+				name = "Jeu Vortex",
+				text = {
+					"Commence avec un Joker {C:cry_exotic}Exotique{C:attention}",
+					"Les Jokers ont {C:attention}20X{} plus",
+					"de chances d'être {C:dark_edition}Négatifs",
+				},
+			},
 		},
 		Blind = {
 			bl_cry_box = {

--- a/localization/id.lua
+++ b/localization/id.lua
@@ -125,6 +125,86 @@ return {
 					"when Boss Blind is defeated {C:inactive}(must have room){}",
 				},
 			},
+
+			b_black_antimatter = {
+				name = "Black Deck",
+				text = {
+					"{C:attention}+#1#{} Slot Joker",
+				},
+			},
+			b_green_antimatter = {
+				name = "Green Deck",
+				text = {
+					"Di akhir setiap Babak:",
+					"{C:money}$#1#{s:0.85} per {C:blue}Hand tersisa",
+					"{C:money}$#2#{s:0.85} per {C:red}Discard tersisa",
+				},
+			},
+			b_nebula_antimatter = {
+				name = "Nebula Deck",
+				text = {
+					"Mulai giliran dengan",
+					"voucher {C:planet,T:v_telescope}#1#{}",
+				},
+			},
+			b_painted_antimatter = {
+				name = "Painted Deck",
+				text = {
+					"{C:attention}+#1#{} Ukuran kartu ditangan",
+				},
+			},
+			b_plasma_antimatter = {
+				name = "Plasma Deck",
+				text = {
+					"Menyeimbangkan {C:blue}Chip{} dan",
+					"{C:red}Mult{} ketika menghitung",
+					"skor untuk giliran yang dimainkan",
+				},
+			},
+			b_cry_beta_antimatter = {
+				name = "Nostalgic Deck",
+				text = {
+					"{C:attention}Joker{} and {C:attention}Consumable{}",
+					"slots are {C:attention}combined",
+				},
+			},
+			b_cry_conveyor_antimatter = {
+				name = "Conveyor Deck",
+				text = {
+					"At start of round,",
+					"{C:attention}duplicate{} rightmost Joker",
+				},
+			},
+			b_cry_critical_antimatter = {
+				name = "Critical Deck",
+				text = {
+					"After each hand played,",
+					"{C:green}#1# in #2#{} chance for {X:dark_edition,C:white} ^2 {} Mult",
+				},
+			},
+			b_cry_encoded_antimatter = {
+				name = "Encoded Deck",
+				text = {
+					"Start with a {C:cry_code,T:j_cry_CodeJoker}Code Joker{}",
+					"and a {C:cry_code,T:j_cry_copypaste}Copy/Paste{}",
+				},
+			},
+			b_cry_spooky_antimatter = {
+				name = "Spooky Deck",
+				text = {
+					"Start with a {C:attention,T:j_cry_chocolate_dice}Chocolate Die",
+					"After each {C:attention}Ante{}, create a",
+					"{C:cry_candy}Candy{} or {X:cry_cursed,C:white}Cursed{} Joker",
+				},
+			},
+			b_cry_wormhole_antimatter = {
+				name = "Wormhole Deck",
+				text = {
+					"Start with an {C:cry_exotic}Exotic{C:attention} Joker",
+					"Jokers are {C:attention}20X{} more",
+					"likely to be {C:dark_edition}Negative",
+				},
+			},
 		},
 		Blind = {
 			bl_cry_box = {

--- a/localization/ja.lua
+++ b/localization/ja.lua
@@ -293,6 +293,86 @@ return {
 					"所持する",
 				},
 			},
+
+			b_black_antimatter = {
+				name = "ブラックデッキ",
+				text = {
+					"ジョーカースロット {C:attention}+#1#{}",
+				},
+			},
+			b_green_antimatter = {
+				name = "グリーンデッキ",
+				text = {
+					"各ラウンドの終了時に",
+					"{s:0.85}残りの {C:blue}ハンド{} ごとに {C:money}$#1#{}",
+					"{s:0.85}残りの {C:red}ディスカード{} ごとに {C:money}$#2#{}",
+				},
+			},
+			b_nebula_antimatter = {
+				name = "ネビュラデッキ",
+				text = {
+					"{C:planet,T:v_telescope}#1#{} のバウチャーを持って",
+					"ランを開始する",
+				},
+			},
+			b_painted_antimatter = {
+				name = "ペインテッドデッキ",
+				text = {
+					"ハンドサイズ {C:attention}+#1#{}",
+				},
+			},
+			b_plasma_antimatter = {
+				name = "プラズマデッキ",
+				text = {
+					"プレイされたハンドのスコアを",
+					"計算する時に",
+					"{C:blue}チップ{} と {C:red}倍率{} のバランスをとる",
+				},
+			},
+			b_cry_beta_antimatter = {
+				name = "郷愁デッキ",
+				text = {
+					"{C:attention}ジョーカー{}と{C:attention}消耗{}スロットが",
+					"{C:attention}合体{}される",
+				},
+			},
+			b_cry_conveyor_antimatter = {
+				name = "コンベアデッキ",
+				text = {
+					"ラウンド開始時",
+					"右端のジョーカーを{C:attention}複製{}する",
+				},
+			},
+			b_cry_critical_antimatter = {
+				name = "クリティカルデッキ",
+				text = {
+					"ハンドをプレイするごとに",
+					"{C:green}#2#分の#1#{}の確率で 倍率 {X:dark_edition,C:white} 2乗 {}",
+				},
+			},
+			b_cry_encoded_antimatter = {
+				name = "エンコーディドデッキ",
+				text = {
+					"1枚の{C:cry_code,T:j_cry_CodeJoker}コードジョーカー{}と",
+					"1枚の{C:cry_code,T:j_cry_copypaste}Copy/Paste{}でランをスタートする",
+				},
+			},
+			b_cry_spooky_antimatter = {
+				name = "不気味なデッキ",
+				text = {
+					"{C:attention,T:j_cry_chocolate_dice}チョコレート・ダイ{}でランをスタートする",
+					"{C:attention}アンティ{}ごとに",
+					"{C:cry_candy}キャンディ{}か{X:cry_cursed,C:white}呪い{}ジョーカーを作る",
+				},
+			},
+			b_cry_wormhole_antimatter = {
+				name = "ワームホールデッキ",
+				text = {
+					"1枚の{C:cry_exotic}エキゾチック{C:attention}ジョーカーでランをスタートする",
+					"{C:dark_edition}ネガティブ{}ジョーカーの出現確率",
+					"{C:attention}20倍{}",
+				},
+			},
 		},
 		Blind = {
 			bl_cry_box = {

--- a/localization/ko.lua
+++ b/localization/ko.lua
@@ -283,6 +283,86 @@ return {
 					"보유",
 				},
 			},
+
+			b_black_antimatter = {
+				name = "블랙 덱",
+				text = {
+					"{C:attention}+#1#{} 개의 조커 슬롯",
+				},
+			},
+			b_green_antimatter = {
+				name = "그린 덱",
+				text = {
+					"각 라운드 종료 시:",
+					"{s:0.85}남은 {C:blue}핸드{} 당 {C:money}$#1#",
+					"{s:0.85}남은 {C:red}버리기{} 당 {C:money}$#2#",
+				},
+			},
+			b_nebula_antimatter = {
+				name = "네뷸라 덱",
+				text = {
+					"{C:planet,T:v_telescope}#1#{} 바우처를 가지고",
+					"런을 시작합니다",
+				},
+			},
+			b_painted_antimatter = {
+				name = "칠한 덱",
+				text = {
+					"{C:attention}+#1#{} 핸드 크기",
+				},
+			},
+			b_plasma_antimatter = {
+				name = "플라스마 덱",
+				text = {
+					"플레이한 핸드의",
+					"점수를 계산할 때 {C:blue}칩{} 과 {C:red}배수{} 의",
+					"균형을 맞춥니다",
+				},
+			},
+			b_cry_beta_antimatter = {
+				name = "추억의 덱",
+				text = {
+					"{C:attention}조커{}와 {C:attention}소모품{}",
+					"슬롯이 {C:attention}통합됨",
+				},
+			},
+			b_cry_conveyor_antimatter = {
+				name = "컨베이어 덱",
+				text = {
+					"라운드 시작 시,",
+					"가장 오른쪽 조커를 {C:attention}복제{}",
+				},
+			},
+			b_cry_critical_antimatter = {
+				name = "크리티컬 덱",
+				text = {
+					"핸드를 낼 때마다,",
+					"{C:green}#2#분의 #1#{} 확률로 {X:dark_edition,C:white}배수 ^2{}",
+				},
+			},
+			b_cry_encoded_antimatter = {
+				name = "인코딩된 덱",
+				text = {
+					"{C:cry_code,T:j_cry_CodeJoker}코드 조커{}와",
+					"{C:cry_code,T:j_cry_copypaste}복사/붙여넣기{}를 가지고 시작",
+				},
+			},
+			b_cry_spooky_antimatter = {
+				name = "으스스한 덱",
+				text = {
+					"{C:attention,T:j_cry_chocolate_dice}초콜릿 주사위{}를 가지고 시작",
+					"{C:attention}앤티{} 종료 시마다,",
+					"{C:cry_candy}캔디{} 또는 {X:cry_cursed,C:white}저주받은{} 조커 생성",
+				},
+			},
+			b_cry_wormhole_antimatter = {
+				name = "웜홀 덱",
+				text = {
+					"{C:cry_exotic}이색적{C:attention} 조커로 런 시작",
+					"조커가 {C:dark_edition}네거티브{}가 될 확률",
+					"{C:attention}20배{} 증가",
+				},
+			},
 		},
 		Blind = {
 			bl_cry_box = {

--- a/localization/nl.lua
+++ b/localization/nl.lua
@@ -132,6 +132,86 @@ return {
 					"{C:attention}-2{} Joker slots",
 				},
 			},
+
+			b_black_antimatter = {
+				name = "Zwart kaartspel",
+				text = {
+					"{C:attention}+#1#{} jokerslot",
+				},
+			},
+			b_green_antimatter = {
+				name = "Groen kaartspel",
+				text = {
+					"Aan het einde van elke ronde:",
+					"{C:money}$#1#{s:0.85} per overgebleven {C:blue}hand",
+					"{C:money}$#2#{s:0.85} per overgebleven {C:red}weggooiing",
+				},
+			},
+			b_nebula_antimatter = {
+				name = "Nevel kaartspel",
+				text = {
+					"Begin het spel met de",
+					"{C:planet,T:v_telescope}#1#{}-voucher",
+				},
+			},
+			b_painted_antimatter = {
+				name = "Geschilderd kaartspel",
+				text = {
+					"{C:attention}+#1#{} handgrootte",
+				},
+			},
+			b_plasma_antimatter = {
+				name = "Plasmakaartspel",
+				text = {
+					"Breng {C:blue}fiches{} en",
+					"{C:red}mult{} in evenwicht bij het berekenen",
+					"van de score voor de gespeelde hand",
+				},
+			},
+			b_cry_beta_antimatter = {
+				name = "Nostalgic Deck",
+				text = {
+					"{C:attention}Joker{} and {C:attention}Consumable{}",
+					"slots are {C:attention}combined",
+				},
+			},
+			b_cry_conveyor_antimatter = {
+				name = "Conveyor Deck",
+				text = {
+					"At start of round,",
+					"{C:attention}duplicate{} rightmost Joker",
+				},
+			},
+			b_cry_critical_antimatter = {
+				name = "Critical Deck",
+				text = {
+					"After each hand played,",
+					"{C:green}#1# in #2#{} chance for {X:dark_edition,C:white} ^2 {} Mult",
+				},
+			},
+			b_cry_encoded_antimatter = {
+				name = "Encoded Deck",
+				text = {
+					"Start with a {C:cry_code,T:j_cry_CodeJoker}Code Joker{}",
+					"and a {C:cry_code,T:j_cry_copypaste}Copy/Paste{}",
+				},
+			},
+			b_cry_spooky_antimatter = {
+				name = "Spooky Deck",
+				text = {
+					"Start with a {C:attention,T:j_cry_chocolate_dice}Chocolate Die",
+					"After each {C:attention}Ante{}, create a",
+					"{C:cry_candy}Candy{} or {X:cry_cursed,C:white}Cursed{} Joker",
+				},
+			},
+			b_cry_wormhole_antimatter = {
+				name = "Wormhole Deck",
+				text = {
+					"Start with an {C:cry_exotic}Exotic{C:attention} Joker",
+					"Jokers are {C:attention}20X{} more",
+					"likely to be {C:dark_edition}Negative",
+				},
+			},
 		},
 		Blind = {
 			bl_cry_box = {

--- a/localization/pl.lua
+++ b/localization/pl.lua
@@ -141,6 +141,86 @@ return {
 					"{C:inactive}(wymaga miejsca){}",
 				},
 			},
+
+			b_black_antimatter = {
+				name = "Czarna talia",
+				text = {
+					"{C:attention}+#1#{} miejsce na jokera",
+				},
+			},
+			b_green_antimatter = {
+				name = "Zielona talia",
+				text = {
+					"Na końcu każdej rundy otrzymujesz:",
+					"{C:money}$#1#{s:0.85} za pozostałą {C:blue}rękę",
+					"{C:money}$#2#{s:0.85} za pozostałą {C:red}zrzutkę",
+				},
+			},
+			b_nebula_antimatter = {
+				name = "Mgławicowa talia",
+				text = {
+					"Rozpoczynasz podejście z",
+					"kuponem {C:planet,T:v_telescope}#1#{}",
+				},
+			},
+			b_painted_antimatter = {
+				name = "Malowana talia",
+				text = {
+					"{C:attention}+#1#{} do rozmiaru ręki",
+				},
+			},
+			b_plasma_antimatter = {
+				name = "Plazmowa talia",
+				text = {
+					"Równoważy {C:blue}żetony{} i",
+					"{C:red}mnożnik{} przy obliczaniu",
+					"punktów za zagraną rękę",
+				},
+			},
+			b_cry_beta_antimatter = {
+				name = "Nostalgiczna Talia",
+				text = {
+					"Miejsca na {C:attention}Jokery{} i {C:attention}Karty Jednorazowe{}",
+					"są {C:attention}połączone",
+				},
+			},
+			b_cry_conveyor_antimatter = {
+				name = "Taśmociągowa Talia",
+				text = {
+					"Na początku rundy",
+					"{C:attention}duplikuje{} jokera najbardziej po prawej",
+				},
+			},
+			b_cry_critical_antimatter = {
+				name = "Krytyczna Talia",
+				text = {
+					"Po każdej zagranej ręce",
+					"{C:green}#1# na #2#{} szans na {X:dark_edition,C:white} ^2 {} mnożnika",
+				},
+			},
+			b_cry_encoded_antimatter = {
+				name = "Zakodowana Talia",
+				text = {
+					"Zaczynasz z {C:cry_code,T:j_cry_CodeJoker}Jokerem Kodu{}",
+					"i {C:cry_code,T:j_cry_copypaste}Kopiuj/Wklej{}",
+				},
+			},
+			b_cry_spooky_antimatter = {
+				name = "Straszliwa Talia",
+				text = {
+					"Zaczynasz z {C:attention,T:j_cry_chocolate_dice}Czekoladową Kostką",
+					"Po każdym {C:attention}Ante{}, stwórz",
+					"{C:cry_candy}Cukierka{} lub {X:cry_cursed,C:white}Przeklętego{} jokera",
+				},
+			},
+			b_cry_wormhole_antimatter = {
+				name = "Tuneloczasowa Talia",
+				text = {
+					"Rozpoczynasz podejście z {C:cry_exotic}egzotycznym{C:attention} jokerem",
+					"{C:attention}X20{} prawdopodobieństwa",
+					"na {C:dark_edition}Negatywy{} jokerów",
+				},
+			},
 		},
 		Blind = {
 			bl_cry_box = {

--- a/localization/pt_BR.lua
+++ b/localization/pt_BR.lua
@@ -193,6 +193,86 @@ return {
 					"{C:inactive}(precisa ter espaço){}",
 				},
 			},
+
+			b_black_antimatter = {
+				name = "Baralho Preto",
+				text = {
+					"{C:attention}+#1#{} Espaço de Curinga",
+				},
+			},
+			b_green_antimatter = {
+				name = "Baralho Verde",
+				text = {
+					"No fim de cada Rodada:",
+					"{C:money}$#1#{s:0.85} por {C:blue}Mão restante",
+					"{C:money}$#2#{s:0.85} por {C:red}Descarte restante",
+				},
+			},
+			b_nebula_antimatter = {
+				name = "Baralho de Nebulosa",
+				text = {
+					"Comece a tentativa com o",
+					"cupom de {C:planet,T:v_telescope}#1#{}",
+				},
+			},
+			b_painted_antimatter = {
+				name = "Baralho Pintado",
+				text = {
+					"{C:attention}+#1#{} tamanho de mão",
+				},
+			},
+			b_plasma_antimatter = {
+				name = "Baralho de Plasma",
+				text = {
+					"Equilibre {C:blue}Fichas{} e",
+					"{C:red}Multi{} ao calcular a",
+					"pontuação para a mão preferida",
+				},
+			},
+			b_cry_beta_antimatter = {
+				name = "Baralho Nostalgico",
+				text = {
+					"{C:attention}Curingas{} e {C:attention}Consumíveis{}",
+					"tem espaços {C:attention}combinados",
+				},
+			},
+			b_cry_conveyor_antimatter = {
+				name = "Baralho Conversor",
+				text = {
+					"No começo da rodada,",
+					"{C:attention}duplique{} O Curinga mais a direita",
+				},
+			},
+			b_cry_critical_antimatter = {
+				name = "Baralho Crítico",
+				text = {
+					"Após cada mão jogada,",
+					"{C:green}#1# em #2#{} de chance para {X:dark_edition,C:white} ^2 {} Mult",
+				},
+			},
+			b_cry_encoded_antimatter = {
+				name = "Baralho Codificado",
+				text = {
+					"Começe com um {C:cry_code,T:j_cry_CodeJoker} Curinga Código{}",
+					"e um {C:cry_code,T:j_cry_copypaste}Copia/Cola{}",
+				},
+			},
+			b_cry_spooky_antimatter = {
+				name = "Baralho Assustador",
+				text = {
+					"Começe com um {C:attention,T:j_cry_chocolate_dice}Dado de Chocolate",
+					"Após cada {C:attention}Aposta{}, crie um",
+					"Curinga {C:cry_candy}Doce{} ou {X:cry_cursed,C:white}Amaldiçoado{}",
+				},
+			},
+			b_cry_wormhole_antimatter = {
+				name = "Baralho Buraco de Minhoca",
+				text = {
+					"Começe com um Curinga {C:cry_exotic}Exótico{C:attention}",
+					"Curingas são {C:attention}20X{} mais suscetíveis",
+					"para serem {C:dark_edition}Negativos",
+				},
+			},
 		},
 		Blind = {
 			bl_cry_box = {

--- a/localization/ru.lua
+++ b/localization/ru.lua
@@ -285,6 +285,86 @@ return {
 					"Используйте {C:spectral}Реплику",
 				},
 			},
+		
+			b_black_antimatter = {
+				name = "Черная колода",
+				text = {
+					"{C:attention}+#1#{} слот джокера",
+				},
+			},
+			b_green_antimatter = {
+				name = "Зеленая колода",
+				text = {
+					"В конце каждого раунда:",
+					"{C:money}$#1#{s:0.85} за каждую оставшуюся {C:blue}руку",
+					"{C:money}$#2#{s:0.85} за каждый оставшийся {C:red}сброс",
+				},
+			},
+			b_nebula_antimatter = {
+				name = "Колода туманности",
+				text = {
+					"Начинаете партию с",
+					"{C:planet,T:v_telescope}#1#{} ваучером",
+				},
+			},
+			b_painted_antimatter = {
+				name = "Рисованная колода",
+				text = {
+					"{C:attention}+#1#{} размер руки",
+				},
+			},
+			b_plasma_antimatter = {
+				name = "Плазменная колода",
+				text = {
+					"Баланс {C:blue}фишек{} и",
+					"{C:red}множ.{} при расчете",
+					"очков для сыгранной руки",
+				},
+			},
+			b_cry_beta_antimatter = {
+				name = "Ностальгическая колода",
+				text = {
+					"Слоты под {C:attention}Джокеры{}",
+					"и под {C:attention}Расходники{} {C:attention}соединены",
+				},
+			},
+			b_cry_conveyor_antimatter = {
+				name = "Конвейерная колода",
+				text = {
+					"в начале раунда,",
+					"{C:attention}дублирует{} самого правого джокера",
+				},
+			},
+			b_cry_critical_antimatter = {
+				name = "Критическая колода",
+				text = {
+					"После каждой сыгранной руки,",
+					"{C:green}#1# к #2#{} шанс для {X:dark_edition,C:white} ^2 {} Множ",
+				},
+			},
+			b_cry_encoded_antimatter = {
+				name = "Закодированная колода",
+				text = {
+					"Начинаете партию с {C:cry_code,T:j_cry_CodeJoker}Код Джокером{}",
+					"и {C:cry_code,T:j_cry_copypaste}Копировать/Вставить{}",
+				},
+			},
+			b_cry_spooky_antimatter = {
+				name = "Жуткая колода",
+				text = {
+					"Начните с {C:attention,T:j_cry_chocolate_dice}Шоколадным кубиком",
+					"после каждого {C:attention}Анте{}, создайте",
+					"{C:cry_candy}Конфету{} или {X:cry_cursed,C:white}Проклятого{} джокера",
+				},
+			},
+			b_cry_wormhole_antimatter = {
+				name = "Колода червоточины",
+				text = {
+					"Начинаете с {C:cry_exotic}Экзотическим{C:attention} Джокером",
+					"Джокеры в {C:attention}20X{} чаще",
+					"появляются {C:dark_edition}Негативными",
+				},
+			},
 		},
 
 		-- ── БЛАЙНДЫ ─────────────────────────────────────────

--- a/localization/ru.lua
+++ b/localization/ru.lua
@@ -285,7 +285,7 @@ return {
 					"Используйте {C:spectral}Реплику",
 				},
 			},
-		
+
 			b_black_antimatter = {
 				name = "Черная колода",
 				text = {

--- a/localization/vi.lua
+++ b/localization/vi.lua
@@ -185,6 +185,86 @@ return {
 					"khi Boss Blind bị đánh bại {C:inactive}(Phải có ô trống)",
 				},
 			},
+
+			b_black_antimatter = {
+				name = "Bộ Bài Đen",
+				text = {
+					"{C:attention}+#1#{} ô Joker",
+				},
+			},
+			b_green_antimatter = {
+				name = "Bộ Bài Xanh Lá",
+				text = {
+					"Vào cuối mỗi Ván:",
+					"{C:money}$#1#{s:0.85} cho mỗi {C:blue}Tay bài{} còn lại",
+					"{C:money}$#2#{s:0.85} cho mỗi lần {C:red}Bỏ bài{} còn lại",
+				},
+			},
+			b_nebula_antimatter = {
+				name = "Bộ Bài Tinh Vân",
+				text = {
+					"Bắt đầu ván với",
+					"voucher {C:planet,T:v_telescope}#1#{}",
+				},
+			},
+			b_painted_antimatter = {
+				name = "Bộ Bài Sơn",
+				text = {
+					"{C:attention}+#1#{} giới hạn bài trên tay",
+				},
+			},
+			b_plasma_antimatter = {
+				name = "Bộ Bài Plasma",
+				text = {
+					"Cân bằng {C:blue}Chip{} và",
+					"{C:red}Nhân{} khi tính điểm",
+					"cho tay bài đã chơi",
+				},
+			},
+			b_cry_beta_antimatter = {
+				name = "Bộ Bài Hoài Niệm",
+				text = {
+					"Gộp ô {C:attention}Joker{} và ô",
+					"{C:attention}Tiêu Thụ{} lại thành một",
+				},
+			},
+			b_cry_conveyor_antimatter = {
+				name = "Bộ Bài Băng Chuyền",
+				text = {
+					"Vào mỗi đầu ván,",
+					"{C:attention}nhân đôi{} Joker ở tít bên phải",
+				},
+			},
+			b_cry_critical_antimatter = {
+				name = "Bộ Bài Chí Mạng",
+				text = {
+					"Sau mỗi tay bài đã chơi,",
+					"Xác suất {C:green}#1# trên #2#{} cho {X:dark_edition,C:white} ^2 {} Nhân",
+				},
+			},
+			b_cry_encoded_antimatter = {
+				name = "Bộ Bài Mã Hóa",
+				text = {
+					"Bắt đầu với {C:cry_code,T:j_cry_CodeJoker}Code Joker{}",
+					"và {C:cry_code,T:j_cry_copypaste}Copy/Paste{}",
+				},
+			},
+			b_cry_spooky_antimatter = {
+				name = "Bộ Bài Ma Quái",
+				text = {
+					"Bắt đầu với {C:attention,T:j_cry_chocolate_dice}Xúc Sắc Sôcôla",
+					"Sau mỗi {C:attention}Ante{}, tạo ra",
+					"viên {C:cry_candy}Kẹo{} hoặc Joker {X:cry_cursed,C:white}Nguyền_Rủa",
+				},
+			},
+			b_cry_wormhole_antimatter = {
+				name = "Bộ Bài Lỗ Giun",
+				text = {
+					"Bắt đầu với một {C:attention}Joker {C:cry_exotic}Ngoại Lai",
+					"Tăng xác suất xuất hiện Joker",
+					"{C:dark_edition}Âm bản lên {C:attention}20 lần",
+				},
+			},
 		},
 		Blind = {
 			bl_cry_box = {

--- a/localization/zh_CN.lua
+++ b/localization/zh_CN.lua
@@ -268,6 +268,84 @@ return {
 					"获得一张{C:cry_exotic}域外{C:attention}小丑",
 				},
 			},
+			b_black_antimatter = {
+				name = "黑色牌组",
+				text = {
+					"{C:attention}+#1#{}个小丑牌位",
+				},
+			},
+			b_green_antimatter = {
+				name = "绿色牌组",
+				text = {
+					"在每轮结束时：",
+					"{C:money}$#1#{s:0.85}每个剩余的出牌机会",
+					"{C:money}$#2#{s:0.85}每个剩余的弃牌机会",
+				},
+			},
+			b_nebula_antimatter = {
+				name = "星云牌组",
+				text = {
+					"开局时拥有",
+					"{C:planet,T:v_telescope}#1#{}优惠券",
+				},
+			},
+			b_painted_antimatter = {
+				name = "涂色牌组",
+				text = {
+					"{C:attention}+#1#{}手牌上限",
+				},
+			},
+			b_plasma_antimatter = {
+				name = "等离子牌组",
+				text = {
+					"在计算出牌得分时",
+					"平衡{C:blue}筹码{}和{C:red}倍率{}",
+				},
+			},
+			b_cry_beta_antimatter = {
+				name = "怀旧牌组",
+				text = {
+					"{C:attention}小丑{}和{C:attention}消耗牌{}",
+					"槽位{C:attention}合并{}",
+				},
+			},
+			b_cry_conveyor_antimatter = {
+				name = "传送带牌组",
+				text = {
+					"在回合开始时，",
+					"{C:attention}复制{}最右侧的小丑",
+				},
+			},
+			b_cry_critical_antimatter = {
+				name = "暴击牌组",
+				text = {
+					"每次出牌后，",
+					"{C:green}#1# / #2#{}几率获得{X:talisman_emult,C:white} ^2 {}倍率",
+				},
+			},
+			b_cry_encoded_antimatter = {
+				name = "编码牌组",
+				text = {
+					"以一张{C:cry_code,T:j_cry_CodeJoker}代码小丑{}",
+					"和一张{C:cry_code,T:j_cry_copypaste}复制/粘贴{}开局",
+				},
+			},
+			b_cry_spooky_antimatter = {
+				name = "万圣节牌组",
+				text = {
+					"以一张{C:attention,T:j_cry_chocolate_dice}巧克力骰{}开局",
+					"每个{C:attention}底注{}结束后，创建一个",
+					"{C:cry_candy}糖果{}或{X:cry_cursed,C:white}诅咒{}小丑",
+				},
+			},
+			b_cry_wormhole_antimatter = {
+				name = "虫洞牌组",
+				text = {
+					"以一张{C:cry_exotic}域外{C:attention}小丑{}开局",
+					"小丑牌成为{C:dark_edition}负片{}的",
+					"概率是原本的{C:attention}20倍{}",
+				},
+			},
 			b_cry_legendary = {
 				name = "传奇牌组",
 				text = {

--- a/localization/zh_TW.lua
+++ b/localization/zh_TW.lua
@@ -125,6 +125,86 @@ return {
 					"when Boss Blind is defeated {C:inactive}(must have room){}",
 				},
 			},
+
+			b_black_antimatter = {
+				name = "黑色牌組",
+				text = {
+					"{C:attention}+#1#{}小丑牌欄位",
+				},
+			},
+			b_green_antimatter = {
+				name = "綠色牌組",
+				text = {
+					"每一回合結束時：",
+					"每剩一次{C:blue}出牌次數，獲得{C:money}$#1#{s:0.85}",
+					"每剩一次{C:red}棄牌次數，獲得{C:money}$#2#{s:0.85}",
+				},
+			},
+			b_nebula_antimatter = {
+				name = "星雲牌組",
+				text = {
+					"開局時得到",
+					"{C:planet,T:v_telescope}#1#{}禮券",
+				},
+			},
+			b_painted_antimatter = {
+				name = "彩繪牌組",
+				text = {
+					"{C:attention}+#1#{}手牌數量",
+				},
+			},
+			b_plasma_antimatter = {
+				name = "等離子牌組",
+				text = {
+					"在計算局數分數時",
+					"平均{C:blue}籌碼{}",
+					"和{C:red}倍數{}",
+				},
+			},
+			b_cry_beta_antimatter = {
+				name = "懷舊牌組",
+				text = {
+					"{C:attention}小丑{}和{C:attention}消耗牌{}",
+					"欄位{C:attention}合併{}",
+				},
+			},
+			b_cry_conveyor_antimatter = {
+				name = "傳送帶牌組",
+				text = {
+					"在回合開始時，",
+					"{C:attention}複製{}最右側的小丑",
+				},
+			},
+			b_cry_critical_antimatter = {
+				name = "暴擊牌組",
+				text = {
+					"每次出牌後，",
+					"{C:green}#1# / #2#{}幾率獲得{X:talisman_emult,C:white} ^2 {}倍率",
+				},
+			},
+			b_cry_encoded_antimatter = {
+				name = "編碼牌組",
+				text = {
+					"以一張{C:cry_code,T:j_cry_CodeJoker}代碼小丑{}",
+					"和一張{C:cry_code,T:j_cry_copypaste}複製/貼上{}開局",
+				},
+			},
+			b_cry_spooky_antimatter = {
+				name = "萬聖節牌組",
+				text = {
+					"以一張{C:attention,T:j_cry_chocolate_dice}巧克力骰{}開局",
+					"每個{C:attention}底注{}結束後，創建一個",
+					"{C:cry_candy}糖果{}或{X:cry_cursed,C:white}詛咒{}小丑",
+				},
+			},
+			b_cry_wormhole_antimatter = {
+				name = "蟲洞牌組",
+				text = {
+					"以一張{C:cry_exotic}域外{C:attention}小丑{}開局",
+					"小丑牌成為{C:dark_edition}負片{}的",
+					"概率是原本的{C:attention}20倍{}",
+				},
+			},
 		},
 		Blind = {
 			bl_cry_box = {


### PR DESCRIPTION
Add custom descriptions to decks that have downsides (like Black, Green, Painted etc) so they would only display upsides instead.