### PR TITLE
Rremove deep_copy from forcetrigger code

### DIFF
--- a/lib/forcetrigger.lua
+++ b/lib/forcetrigger.lua
@@ -35,7 +35,7 @@ function Cryptid.forcetrigger(card, context)
 		}))
 	end
 	if not check and card.ability.set == "Joker" then
-		local demicontext = Cryptid.deep_copy(context)
+		local demicontext = SMODS.shallow_copy(context or {})
 		demicontext.forcetrigger = true
 		results = eval_card(card, demicontext)
 		demicontext = nil

--- a/lib/misc.lua
+++ b/lib/misc.lua
@@ -374,7 +374,7 @@ function Cryptid.with_deck_effects(card, func)
 end
 
 function Cryptid.deep_copy(obj, seen)
-	if type(obj) ~= "table" then
+	if type(obj) ~= "table" or (obj.is and obj:is(Object)) then
 		return obj
 	end
 	if seen and seen[obj] then


### PR DESCRIPTION
- Remove a `Cryptid.deep_copy` function from `forcetrigger` function that was just there... for some reason
- Also add a guard in `deep_copy` to prevent any further crashes